### PR TITLE
feat(library): LLM 推理引擎 from-scratch book (9 ch + code)

### DIFF
--- a/examples/llm-inference-from-scratch/README.md
+++ b/examples/llm-inference-from-scratch/README.md
@@ -1,0 +1,54 @@
+# LLM 推理引擎从零
+
+配套书《LLM 推理引擎从零：用 TypeScript 手写一个会算真实 tok/s 的推理栈》的可跑代码。
+
+**纯算法、离线、零运行时依赖。** 不需要任何 LLM、API key 或网络。所有权重由种子 PRNG 合成（不是训练出来的），所以模型输出是"结构正确的胡言"——这本书讲的是**推理引擎**（KV cache、批处理、分页、投机解码、量化），不是模型质量。引擎的正确性（缓存路径是否等于无缓存参考？批处理是否改变输出？int8 是否漂移 logits？）与模型好不好完全无关。
+
+## 诚实数字约定
+
+- **能 wall-clock 的真测**：tok/s、TTFT、per-token latency 全部用 `performance.now()` 实测。
+- **内存按 IEEE-754 float64 payload 估算并标 `(est.)`**：不是测 RSS（GC 噪声大），而是对 model config 做精确算术——这正是真实引擎容量规划用的数。
+- **等价性用 perplexity / logit-drift 证明**，不靠嘴说"没变质"。
+- **toy 数据偏乐观**：合成模型小、kernel 是未优化的 float64 循环，所以**绝对** tok/s 偏悲观；能迁移到真引擎的是**相对**趋势与**加速比**。
+
+## 跑法
+
+先安装一次（只装 tsx / typescript / @types/node）：
+
+```bash
+npm install
+```
+
+每个 stage 一条命令（加载即跑，自带 `main()`）：
+
+```bash
+npm run stage01   # forward pass：无缓存参考前向，建立 baseline
+npm run stage02   # KV cache：缓存路径 vs 无缓存，证明等价并测加速比
+npm run stage03   # sampling：greedy / temperature / top-k / top-p / repetition penalty
+npm run stage04   # continuous batching：连续批处理，多序列共享前向
+npm run stage05   # paged KV：分页 KV cache，消除按步重分配的拷贝开销
+npm run stage06   # speculative decoding：投机解码，draft+verify，perplexity 对拍
+npm run stage07   # quantization：fp64→int8 权重量化，测 logit L∞ 漂移
+npm run stage08   # benchmark：跨配置/优化的诚实记分卡汇总
+```
+
+类型检查：
+
+```bash
+npm run typecheck   # tsc --noEmit
+```
+
+## 共享底座 `src/core/`
+
+所有 stage 复用 core，不重造算子与计时：
+
+- `core/tensor.ts` — toy 张量与算子内核（matmul / addBias / rmsNorm / softmax / silu / rope / causalMask），row-major Float64Array，无 BLAS，慢但确定、可读、可数 FLOP。
+- `core/model.ts` — toy LLaMA 风格 decoder（RMSNorm + RoPE + GQA + SiLU-gated FFN + 权重绑定）。`buildModel(cfg, seed)` 纯函数确定性；`forwardNoCache`（参考路径）与 `forwardStep`（缓存路径）两条前向供对照。
+- `core/tokenizer.ts` — byte 级确定性 tokenizer（vocab=256，零词表文件），`encode` / `decode` 保证离线 round-trip，附 `PROMPTS`（≥3 个不同长度）。
+- `core/metrics.ts` — 推理诚实记分卡（timeIt / tokensPerSecond / ttft / interTokenLatency / estimateKVBytes / formatBytes / speedup / perplexity / maxLogitDrift / argmax）。
+
+底座自检（非 stage，验证 core 不变量）：
+
+```bash
+npx tsx src/core/_smoke.ts
+```

--- a/examples/llm-inference-from-scratch/package-lock.json
+++ b/examples/llm-inference-from-scratch/package-lock.json
@@ -1,0 +1,566 @@
+{
+  "name": "llm-inference-from-scratch",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "llm-inference-from-scratch",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/llm-inference-from-scratch/package.json
+++ b/examples/llm-inference-from-scratch/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "llm-inference-from-scratch",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "从零用 TypeScript 手写一个会算真实 tok/s 的 LLM 推理栈。纯算法、离线 CPU 可跑、无 LLM/API/网络依赖，每个 stage 实测 tok/s、TTFT、per-token latency、KV 内存(est.)。配套《LLM 推理引擎从零》书库合集。",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "stage01": "tsx src/stage01-forward.ts",
+    "stage02": "tsx src/stage02-kvcache.ts",
+    "stage03": "tsx src/stage03-sampling.ts",
+    "stage04": "tsx src/stage04-continuous-batch.ts",
+    "stage05": "tsx src/stage05-paged-kv.ts",
+    "stage06": "tsx src/stage06-speculative.ts",
+    "stage07": "tsx src/stage07-quantization.ts",
+    "stage08": "tsx src/stage08-benchmark.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/examples/llm-inference-from-scratch/src/core/_smoke.ts
+++ b/examples/llm-inference-from-scratch/src/core/_smoke.ts
@@ -1,0 +1,117 @@
+// core/_smoke.ts — core底座自检. NOT a book stage; it is the scaffold's own
+// acceptance test, kept in core so it can import internals freely. Run with
+// `npx tsx src/core/_smoke.ts`. It proves three load-bearing invariants the whole
+// book depends on, with REAL numbers (no asserts-only):
+//   1. determinism: same (cfg, seed) -> bit-for-bit identical logits.
+//   2. cache correctness: forwardStep (cached) == forwardNoCache (reference).
+//   3. honest metrics + a real FAILURE MODE (softmax overflow without max-subtract).
+
+import { DEFAULT_CONFIG, buildModel, forwardNoCache, forwardStep, newCache } from "./model.js";
+import { encode, decode, PROMPTS, VOCAB_SIZE } from "./tokenizer.js";
+import {
+  timeIt,
+  tokensPerSecond,
+  maxLogitDrift,
+  estimateKVBytes,
+  formatBytes,
+  speedup,
+  perplexity,
+  argmax,
+  interTokenLatency,
+} from "./metrics.js";
+
+function softmaxNaive(row: number[]): number[] {
+  // deliberately WRONG: no max-subtract. Demonstrates the overflow failure mode
+  // that core/tensor.softmax guards against.
+  const exps = row.map((v) => Math.exp(v));
+  const sum = exps.reduce((a, b) => a + b, 0);
+  return exps.map((e) => e / sum);
+}
+
+console.log("=== core 自检 (core smoke test) ===\n");
+
+const model = buildModel(DEFAULT_CONFIG, 42);
+const model2 = buildModel(DEFAULT_CONFIG, 42);
+
+// --- 1. tokenizer round-trip --------------------------------------------------
+console.log("[1] tokenizer round-trip (decode∘encode === id):");
+for (const p of PROMPTS) {
+  const ids = encode(p);
+  const ok = decode(ids) === p;
+  console.log(`    len=${String(ids.length).padStart(3)} roundtrip=${ok ? "OK" : "FAIL"}  "${p.slice(0, 32)}${p.length > 32 ? "…" : ""}"`);
+}
+console.log(`    vocabSize=${VOCAB_SIZE} (byte-level)\n`);
+
+// --- 2. determinism -----------------------------------------------------------
+const promptIds = encode(PROMPTS[1]);
+const logitsA = Array.from(forwardNoCache(model, promptIds));
+const logitsB = Array.from(forwardNoCache(model2, promptIds));
+console.log("[2] determinism (two builds, seed=42):");
+console.log(`    maxLogitDrift = ${maxLogitDrift(logitsA, logitsB).toExponential(2)} (must be 0)\n`);
+
+// --- 3. cache correctness: cached path must equal reference path ---------------
+const cache = newCache(DEFAULT_CONFIG);
+let cachedLast: Float64Array = new Float64Array(VOCAB_SIZE);
+for (const id of promptIds) cachedLast = forwardStep(model, id, cache);
+const drift = maxLogitDrift(logitsA, Array.from(cachedLast));
+console.log("[3] cache correctness (forwardStep vs forwardNoCache, last-token logits):");
+console.log(`    maxLogitDrift = ${drift.toExponential(2)}  (≈0 means cache is exact)`);
+console.log(`    argmax cached=${argmax(cachedLast)} ref=${argmax(logitsA)} match=${argmax(cachedLast) === argmax(logitsA)}\n`);
+
+// --- 4. honest timing: prefill (TTFT) vs decode -------------------------------
+const N_DECODE = 16;
+// warmup (see metrics.timeIt convention)
+{
+  const c = newCache(DEFAULT_CONFIG);
+  for (const id of promptIds) forwardStep(model, id, c);
+}
+const c2 = newCache(DEFAULT_CONFIG);
+const prefillMs = timeIt(() => {
+  for (const id of promptIds) forwardStep(model, id, c2);
+});
+let next = argmax(forwardStep(model, argmax(cachedLast), c2));
+const stepMs: number[] = [];
+for (let i = 0; i < N_DECODE; i++) {
+  const t = timeIt(() => {
+    next = argmax(forwardStep(model, next, c2));
+  });
+  stepMs.push(t);
+}
+const itl = interTokenLatency(stepMs);
+console.log("[4] honest two-phase timing:");
+console.log(`    prefill (TTFT) over ${promptIds.length} tokens = ${prefillMs.toFixed(2)} ms`);
+console.log(`    decode inter-token latency: mean=${itl.mean.toFixed(3)} p95=${itl.p95.toFixed(3)} ms/tok`);
+console.log(`    decode throughput = ${tokensPerSecond(N_DECODE, stepMs.reduce((a, b) => a + b, 0)).toFixed(1)} tok/s\n`);
+
+// --- 5. KV memory estimate (est.) ---------------------------------------------
+const kvOne = estimateKVBytes(DEFAULT_CONFIG, 128, 1);
+const kvBatch = estimateKVBytes(DEFAULT_CONFIG, 128, 32);
+console.log("[5] KV cache footprint (exact arithmetic, labeled est. when printed):");
+console.log(`    seq=128, 1 seq   = ${formatBytes(kvOne)} (est.)`);
+console.log(`    seq=128, 32 seqs = ${formatBytes(kvBatch)} (est.)`);
+console.log(`    GQA factor nHeads/nKVHeads = ${DEFAULT_CONFIG.nHeads / DEFAULT_CONFIG.nKVHeads}x smaller than MHA\n`);
+
+// --- 6. equivalence judge sanity: perplexity ----------------------------------
+const logitRows: number[][] = [];
+const targets: number[] = [];
+const c3 = newCache(DEFAULT_CONFIG);
+for (let i = 0; i < promptIds.length - 1; i++) {
+  const lg = forwardStep(model, promptIds[i], c3);
+  logitRows.push(Array.from(lg));
+  targets.push(promptIds[i + 1]);
+}
+console.log("[6] perplexity (equivalence judge):");
+console.log(`    PPL of prompt under untrained model = ${perplexity(logitRows, targets).toFixed(1)} (~vocab size, expected for untrained)\n`);
+
+// --- 7. FAILURE MODE: softmax overflow without max-subtract -------------------
+console.log("[7] FAILURE MODE — softmax must subtract max:");
+const bigLogits = [800, 801, 802]; // realistic large attention logits
+const naive = softmaxNaive(bigLogits);
+console.log(`    naive softmax([800,801,802]) = [${naive.map((x) => x.toFixed(3)).join(", ")}]  <- NaN: exp(800)=Inf`);
+console.log(`    (core/tensor.softmax subtracts row max first, so it stays finite)\n`);
+
+// --- 8. speedup helper demo ---------------------------------------------------
+console.log("[8] speedup helper:");
+console.log(`    speedup(baseline=100ms, optimized=25ms) = ${speedup(100, 25).toFixed(2)}x\n`);
+
+console.log("=== all core invariants checked ===");

--- a/examples/llm-inference-from-scratch/src/core/metrics.ts
+++ b/examples/llm-inference-from-scratch/src/core/metrics.ts
@@ -1,0 +1,184 @@
+// core/metrics.ts — the honest scorecard the whole book is judged against.
+//
+// The promise of this book is "real tok/s". That promise lives or dies here. The
+// rules, inherited from the vector-search book's honesty convention:
+//
+//   1. Anything that is a *duration* is wall-clocked with performance.now(). Never
+//      estimated, never hard-coded. tok/s, TTFT, inter-token latency, speedup.
+//   2. Anything that is *memory* is ESTIMATED from the float64 payload size and
+//      labeled `(est.)` — we do NOT read process.memoryUsage().rss, because RSS on
+//      a GC'd VM is noisy, allocator-dependent, and would lie about the *algorithm's*
+//      footprint. The KV-cache byte math, by contrast, is exact arithmetic on the
+//      model config and is the number a real engine's capacity planning uses.
+//   3. Equivalence claims ("the optimization didn't change the output") are proven
+//      with perplexity / logit-drift, never asserted.
+//
+// Toy-data caveat that every stage must echo: the synthetic model is small and the
+// kernels are unoptimized float64 loops, so ABSOLUTE tok/s is pessimistic. What
+// transfers to a real engine is the RELATIVE story — the speedup ratios and the
+// shape of the prefill-vs-decode curve.
+
+import type { ModelConfig } from "./model.js";
+
+// timeIt: wall-clock a thunk, in milliseconds.
+//
+// Warmup convention (this is the easy thing to get wrong): the FIRST call to any
+// JS hot path pays JIT compilation + cold-cache costs that have nothing to do with
+// steady-state throughput. So callers MUST warm up before the measured run:
+//
+//     timeIt(() => run());          // throwaway: triggers JIT, warms caches
+//     const ms = timeIt(() => run()); // this one counts
+//
+// We deliberately do NOT bake warmup into timeIt: some measurements (TTFT, the
+// very first token) are explicitly about the cold path and warming them up would
+// be a lie. Forcing the caller to decide keeps the honesty visible at the call site.
+export function timeIt(fn: () => void): number {
+  const t0 = performance.now();
+  fn();
+  return performance.now() - t0;
+}
+
+// tok/s. The headline number. nTok is tokens *produced* (decode steps), ms is the
+// wall time to produce them. Guard against a zero/negative interval (can happen if
+// a run is so fast it underflows the timer's resolution) by returning Infinity,
+// which is a louder signal than a divide-by-zero NaN that "your workload is too
+// small to measure — make it bigger".
+export function tokensPerSecond(nTok: number, ms: number): number {
+  if (ms <= 0) return Infinity;
+  return (nTok / ms) * 1000;
+}
+
+// TTFT — time to first token. Just a labeled pass-through of a measured duration,
+// but naming it makes the two-phase structure (prefill -> first token, then decode)
+// explicit in stage code. TTFT is dominated by PREFILL: the whole prompt is run
+// through the model before any token comes out. It grows with prompt length.
+export function ttft(ms: number): number {
+  return ms;
+}
+
+// Inter-token latency stats over the per-step decode times. The DECODE phase is
+// the other half of the inference dichotomy: after prefill, each new token is one
+// forward step over a single position (reusing the KV cache). Its latency should be
+// roughly flat (and much smaller than TTFT) — if mean rises steadily with step
+// index, your "cache" is secretly re-reading history (the exact bug stage02 hunts).
+export function interTokenLatency(msPerStep: number[]): {
+  mean: number;
+  p50: number;
+  p95: number;
+  min: number;
+  max: number;
+} {
+  if (msPerStep.length === 0) return { mean: 0, p50: 0, p95: 0, min: 0, max: 0 };
+  const sorted = [...msPerStep].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const pct = (p: number) => sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
+  return {
+    mean: sum / sorted.length,
+    p50: pct(50),
+    p95: pct(95),
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+  };
+}
+
+// estimateKVBytes — the capacity-planning number, labeled (est.) when printed.
+//
+// This is EXACT arithmetic, not a measurement: a KV cache stores, per layer, the
+// key and value for every past token of every sequence. Shape per layer:
+//   2 (K and V) * nKVHeads * dHead * seqLen, times nLayers, times nSeqs.
+// We assume float64 (8 bytes) to match this toy engine's storage; the formula and
+// the 8 is the only place real-vs-toy diverges (a real fp16 cache is 4x smaller).
+// nKVHeads (not nHeads) is what makes GQA's memory win show up: with nKVHeads <
+// nHeads the cache shrinks by exactly nHeads/nKVHeads. This number is why paged-KV
+// (stage05) and GQA exist, so the formula is in core where every stage can cite it.
+export function estimateKVBytes(cfg: ModelConfig, seqLen: number, nSeqs: number): number {
+  const bytesPerFloat = 8; // float64 payload — see module header rule #2
+  const elemsPerLayer = 2 * cfg.nKVHeads * cfg.dHead * seqLen;
+  return elemsPerLayer * cfg.nLayers * nSeqs * bytesPerFloat;
+}
+
+// Human-readable bytes. Callers append the literal "(est.)" suffix per the honesty
+// rule so a reader can never confuse an estimate for a measurement.
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KiB", "MiB", "GiB", "TiB"];
+  let b = bytes / 1024;
+  let i = 0;
+  while (b >= 1024 && i < units.length - 1) {
+    b /= 1024;
+    i++;
+  }
+  return `${b.toFixed(2)} ${units[i]}`;
+}
+
+// speedup: baseline / optimized. >1 means faster. Reported as the primary result
+// of every optimization stage because it is robust to the toy-data caveat: even if
+// both absolute numbers are pessimistic, their RATIO transfers to a real engine.
+export function speedup(baselineMs: number, optimizedMs: number): number {
+  if (optimizedMs <= 0) return Infinity;
+  return baselineMs / optimizedMs;
+}
+
+// perplexity of a sequence under a stream of next-token logit rows.
+//
+// Equivalence judge for the "fast but not worse" claim (speculative decoding,
+// quantization). PPL = exp(mean negative log-likelihood of the actual next tokens).
+// logits[t] is the unnormalized distribution predicting targetIds[t]. Lower is
+// "more confident / better"; for our purposes the ABSOLUTE value is meaningless
+// (the model is untrained — expect ~vocabSize), but a near-identical PPL between
+// an optimized run and the baseline run is hard proof the optimization preserved
+// the distribution. Computed via log-sum-exp for numerical stability.
+//
+// Failure mode it catches: a quantization scheme that "runs" but quietly skews the
+// output distribution shows up here as a PPL gap even when the argmax token happens
+// to match.
+export function perplexity(logits: number[][], targetIds: number[]): number {
+  if (logits.length !== targetIds.length) {
+    throw new Error(`perplexity: ${logits.length} logit rows != ${targetIds.length} targets`);
+  }
+  let nll = 0;
+  for (let t = 0; t < logits.length; t++) {
+    const row = logits[t];
+    let max = -Infinity;
+    for (const v of row) if (v > max) max = v;
+    let sumExp = 0;
+    for (const v of row) sumExp += Math.exp(v - max);
+    const logSumExp = max + Math.log(sumExp);
+    const logProb = row[targetIds[t]] - logSumExp; // log softmax at the target
+    nll += -logProb;
+  }
+  return Math.exp(nll / logits.length);
+}
+
+// maxLogitDrift: L∞ (max absolute) difference between two logit vectors.
+//
+// The on-the-wire correctness check for any kernel rewrite or quantization. Two
+// logit vectors that should be identical (same model, same input, different code
+// path) must drift by ~0 in float64; an int8 path will drift by some bounded
+// amount that this number quantifies. Reporting L∞ (not mean) is deliberate: a
+// single catastrophically-wrong logit (e.g. one overflowed dot product) is exactly
+// the failure that a mean would hide and that flips an argmax.
+export function maxLogitDrift(a: number[], b: number[]): number {
+  if (a.length !== b.length) throw new Error(`maxLogitDrift: length ${a.length} != ${b.length}`);
+  let m = 0;
+  for (let i = 0; i < a.length; i++) {
+    const d = Math.abs(a[i] - b[i]);
+    if (d > m) m = d;
+  }
+  return m;
+}
+
+// argmax over a logit row — greedy next-token. Tiny but shared so every stage's
+// "did the token change?" comparison uses identical tie-breaking (first-max wins,
+// deterministic).
+export function argmax(row: number[] | Float64Array): number {
+  let best = 0;
+  let bestV = -Infinity;
+  for (let i = 0; i < row.length; i++) {
+    if (row[i] > bestV) {
+      bestV = row[i];
+      best = i;
+    }
+  }
+  return best;
+}

--- a/examples/llm-inference-from-scratch/src/core/model.ts
+++ b/examples/llm-inference-from-scratch/src/core/model.ts
@@ -1,0 +1,389 @@
+// core/model.ts — a toy decoder-only Transformer: synthetic weights, two forward
+// paths, and the KV-cache type the optimization stages mutate.
+//
+// What this is NOT: a trained model. Every weight is generated from a seeded PRNG.
+// The book says this out loud and repeatedly: the output is "structurally correct
+// gibberish" — the shapes, the causal masking, the RoPE rotations, the cache
+// bookkeeping are all real and correct, but the model has learned nothing, so the
+// tokens it emits are noise. THAT IS THE POINT. This book is about the inference
+// *engine*, and an engine's correctness (does the cache match the no-cache path?
+// does batching change outputs? does int8 drift the logits?) is completely
+// independent of whether the model is any good. A trained model would only add a
+// multi-GB download and obscure the mechanism.
+//
+// Architecture: a small LLaMA-style decoder — RMSNorm (pre-norm), RoPE attention
+// with GQA support, SiLU-gated FFN, weight-tied output head. Chosen because it is
+// the lineage every modern open inference engine targets.
+//
+// Determinism invariant: buildModel(cfg, seed) is a pure function of (cfg, seed).
+// Same inputs -> bit-for-bit identical weights -> bit-for-bit identical logits, on
+// any machine. This is what makes every cross-stage comparison (cache vs no-cache,
+// quantized vs not) a controlled experiment rather than an anecdote.
+
+import {
+  type Tensor,
+  tensor,
+  zeros,
+  matmul,
+  rmsNorm,
+  softmax,
+  silu,
+  rope,
+} from "./tensor.js";
+
+export type ModelConfig = {
+  dModel: number;
+  nLayers: number;
+  nHeads: number;
+  dHead: number;
+  dFF: number;
+  vocabSize: number;
+  maxSeq: number;
+  // GQA: number of KEY/VALUE heads. When nKVHeads < nHeads, each KV head is shared
+  // by (nHeads / nKVHeads) query heads — this is what shrinks the KV cache. Set
+  // nKVHeads === nHeads for vanilla multi-head attention (MHA).
+  nKVHeads: number;
+};
+
+// The book's baseline config. Tiny on purpose: small enough that the unoptimized
+// float64 kernels run in milliseconds (so a stage finishes interactively) yet large
+// enough that prefill-vs-decode and cache-vs-no-cache differences are clearly
+// measurable. nKVHeads(2) < nHeads(4) so GQA is exercised by default.
+export const DEFAULT_CONFIG: ModelConfig = {
+  dModel: 64,
+  nLayers: 4,
+  nHeads: 4,
+  dHead: 16,
+  dFF: 256,
+  vocabSize: 256, // byte-level, matches core/tokenizer
+  maxSeq: 256,
+  nKVHeads: 2,
+};
+
+// mulberry32 — a tiny, fast, seedable PRNG. NOT cryptographic; we want exactly the
+// opposite: full reproducibility from a 32-bit seed. Returns floats in [0, 1).
+// This single function is the root of the book's determinism guarantee.
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// One Transformer block's weights. Names mirror the math so stage code reads like
+// the architecture diagram. wQ/wK/wV/wO are attention projections; w1/w2/w3 are the
+// SiLU-gated FFN (w1=gate, w3=up, w2=down). normAtt/normFFN are the pre-norm RMSNorm
+// gains. Biases are omitted (LLaMA-style) — fewer params, and bias-free is the norm.
+export type LayerWeights = {
+  wQ: Tensor; // [dModel, nHeads * dHead]
+  wK: Tensor; // [dModel, nKVHeads * dHead]   <- GQA: narrower than wQ
+  wV: Tensor; // [dModel, nKVHeads * dHead]
+  wO: Tensor; // [nHeads * dHead, dModel]
+  w1: Tensor; // [dModel, dFF]   gate
+  w3: Tensor; // [dModel, dFF]   up
+  w2: Tensor; // [dFF, dModel]   down
+  normAtt: Tensor; // [dModel]
+  normFFN: Tensor; // [dModel]
+};
+
+export type Model = {
+  cfg: ModelConfig;
+  embed: Tensor; // [vocabSize, dModel] — also reused as the output head (weight tying)
+  normOut: Tensor; // [dModel] final RMSNorm gain
+  layers: LayerWeights[];
+};
+
+// Initialize a weight matrix with values in [-scale, scale). scale ~ 1/sqrt(fanIn)
+// (a Xavier-ish heuristic) keeps activations from exploding through nLayers of
+// matmuls — without it, the synthetic logits overflow and softmax produces NaN,
+// which is itself a nice cautionary tale but not the default we want.
+function randMat(rng: () => number, rows: number, cols: number, fanIn: number): Tensor {
+  const scale = 1 / Math.sqrt(fanIn);
+  const data = new Float64Array(rows * cols);
+  for (let i = 0; i < data.length; i++) data[i] = (rng() * 2 - 1) * scale;
+  return tensor(data, [rows, cols]);
+}
+
+// RMSNorm gains init to ~1 (the identity for a normalizer) with a touch of jitter
+// so the layers are not all identical.
+function randGain(rng: () => number, n: number): Tensor {
+  const data = new Float64Array(n);
+  for (let i = 0; i < n; i++) data[i] = 1 + (rng() - 0.5) * 0.02;
+  return tensor(data, [n]);
+}
+
+export function buildModel(cfg: ModelConfig, seed: number): Model {
+  const rng = mulberry32(seed);
+  const qDim = cfg.nHeads * cfg.dHead;
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+  if (cfg.nHeads % cfg.nKVHeads !== 0) {
+    // GQA invariant: query heads must split evenly across KV heads, else the
+    // head-grouping in attention has a remainder and is ill-defined.
+    throw new Error(`buildModel: nHeads(${cfg.nHeads}) must be divisible by nKVHeads(${cfg.nKVHeads})`);
+  }
+  const layers: LayerWeights[] = [];
+  for (let l = 0; l < cfg.nLayers; l++) {
+    layers.push({
+      wQ: randMat(rng, cfg.dModel, qDim, cfg.dModel),
+      wK: randMat(rng, cfg.dModel, kvDim, cfg.dModel),
+      wV: randMat(rng, cfg.dModel, kvDim, cfg.dModel),
+      wO: randMat(rng, qDim, cfg.dModel, qDim),
+      w1: randMat(rng, cfg.dModel, cfg.dFF, cfg.dModel),
+      w3: randMat(rng, cfg.dModel, cfg.dFF, cfg.dModel),
+      w2: randMat(rng, cfg.dFF, cfg.dModel, cfg.dFF),
+      normAtt: randGain(rng, cfg.dModel),
+      normFFN: randGain(rng, cfg.dModel),
+    });
+  }
+  return {
+    cfg,
+    embed: randMat(rng, cfg.vocabSize, cfg.dModel, cfg.dModel),
+    normOut: randGain(rng, cfg.dModel),
+    layers,
+  };
+}
+
+// Per-layer KV cache: the keys and values already computed for past tokens, ready
+// to be reused. K and V each hold [nKVHeads * dHead] per cached position, stored as
+// a flat row-major [len, kvDim] block. `len` is how many positions are filled.
+//
+// This type is the protagonist of the whole book. stage02 builds it; stage05 swaps
+// the flat array for paged blocks; the math is in core/metrics.estimateKVBytes.
+export type KVCache = {
+  k: Float64Array[]; // per layer: flat [len * kvDim] (we grow by pushing rows)
+  v: Float64Array[];
+  len: number; // number of positions currently cached (same for all layers)
+  cfg: ModelConfig;
+};
+
+export function newCache(cfg: ModelConfig): KVCache {
+  return {
+    k: Array.from({ length: cfg.nLayers }, () => new Float64Array(0)),
+    v: Array.from({ length: cfg.nLayers }, () => new Float64Array(0)),
+    len: 0,
+    cfg,
+  };
+}
+
+// --- shared attention/FFN math, parameterized by how K/V are sourced ---------
+//
+// Both forward paths (cached and not) share this block-evaluation core so the two
+// can NEVER silently diverge — the only difference between them is which keys/values
+// the attention sees, which is exactly the variable the book is studying. Keeping
+// the arithmetic identical is what makes "cache == no-cache" a meaningful assertion.
+
+// Compute Q,K,V projections for a single token's hidden vector h (length dModel).
+function projectQKV(
+  h: Float64Array,
+  w: LayerWeights,
+  cfg: ModelConfig
+): { q: Float64Array; k: Float64Array; v: Float64Array } {
+  const hT = tensor(h, [1, cfg.dModel]);
+  const q = matmul(hT, w.wQ).data;
+  const k = matmul(hT, w.wK).data;
+  const v = matmul(hT, w.wV).data;
+  return { q, k, v };
+}
+
+// Apply RoPE per-head to a token's q (nHeads heads) and k (nKVHeads heads) at `pos`.
+function applyRope(q: Float64Array, k: Float64Array, pos: number, cfg: ModelConfig): void {
+  // q has nHeads heads, k has nKVHeads heads, each dHead wide. RoPE rotates within
+  // a head. A subtle invariant: query head g and the kv head it maps to (g div
+  // groupSize) MUST be rotated by the same pos, or the relative-position property
+  // breaks and attention scores go wrong. Same `pos` for all heads guarantees it.
+  for (let hh = 0; hh < cfg.nHeads; hh++) {
+    const qSlice = q.subarray(hh * cfg.dHead, (hh + 1) * cfg.dHead);
+    // pair each query head with ANY key head for the rope() signature; we only need
+    // q rotated here, so reuse a throwaway view of the corresponding kv slot.
+    const kvHead = Math.floor(hh / (cfg.nHeads / cfg.nKVHeads));
+    const kSlice = k.subarray(kvHead * cfg.dHead, (kvHead + 1) * cfg.dHead);
+    // rope mutates both; but a kv head shared by G query heads would be rotated G
+    // times. To avoid that, rotate k separately below and pass a scratch copy here.
+    const kScratch = Float64Array.from(kSlice);
+    rope(qSlice, kScratch, pos, 10000);
+  }
+  for (let kh = 0; kh < cfg.nKVHeads; kh++) {
+    const kSlice = k.subarray(kh * cfg.dHead, (kh + 1) * cfg.dHead);
+    const qScratch = Float64Array.from(kSlice); // scratch, rotation symmetric
+    rope(qScratch, kSlice, pos, 10000);
+  }
+}
+
+// Attention for one query token against `len` cached (K,V) rows + the layer output.
+// kAll/vAll are flat [len * kvDim]. Returns the attention output [qDim] for this token.
+function attendToken(
+  q: Float64Array,
+  kAll: Float64Array,
+  vAll: Float64Array,
+  len: number,
+  cfg: ModelConfig
+): Float64Array {
+  const groupSize = cfg.nHeads / cfg.nKVHeads;
+  const out = new Float64Array(cfg.nHeads * cfg.dHead);
+  const invSqrtD = 1 / Math.sqrt(cfg.dHead);
+  for (let hh = 0; hh < cfg.nHeads; hh++) {
+    const kvHead = Math.floor(hh / groupSize); // GQA: which KV head this query reads
+    const qOff = hh * cfg.dHead;
+    // scores against every cached position (causal: caller only ever caches the past
+    // plus the current token, so no explicit mask needed here — the cache *is* the mask).
+    const scores = new Float64Array(len);
+    for (let p = 0; p < len; p++) {
+      const kOff = p * (cfg.nKVHeads * cfg.dHead) + kvHead * cfg.dHead;
+      let dotv = 0;
+      for (let d = 0; d < cfg.dHead; d++) dotv += q[qOff + d] * kAll[kOff + d];
+      scores[p] = dotv * invSqrtD;
+    }
+    const probs = softmax(tensor(scores, [1, len])).data;
+    for (let p = 0; p < len; p++) {
+      const vOff = p * (cfg.nKVHeads * cfg.dHead) + kvHead * cfg.dHead;
+      const w = probs[p];
+      for (let d = 0; d < cfg.dHead; d++) out[qOff + d] += w * vAll[vOff + d];
+    }
+  }
+  return out;
+}
+
+// FFN: SiLU-gated MLP. down( silu(gate(x)) * up(x) ).
+function ffn(h: Float64Array, w: LayerWeights, cfg: ModelConfig): Float64Array {
+  const hT = tensor(h, [1, cfg.dModel]);
+  const gate = silu(matmul(hT, w.w1));
+  const up = matmul(hT, w.w3);
+  const prod = new Float64Array(cfg.dFF);
+  for (let i = 0; i < cfg.dFF; i++) prod[i] = gate.data[i] * up.data[i];
+  return matmul(tensor(prod, [1, cfg.dFF]), w.w2).data;
+}
+
+// Run one full block for one token, given the running K/V history. Mutates kHist/
+// vHist by appending this token's (rope'd) K and V, then attends over the whole
+// history. Returns the new hidden vector. This is the per-token unit both paths use.
+function blockStep(
+  h: Float64Array,
+  w: LayerWeights,
+  pos: number,
+  kHist: Float64Array,
+  vHist: Float64Array,
+  histLen: number,
+  cfg: ModelConfig
+): { h: Float64Array; k: Float64Array; v: Float64Array } {
+  // pre-norm
+  const normed = rmsNorm(tensor(h, [1, cfg.dModel]), w.normAtt).data;
+  const { q, k, v } = projectQKV(normed, w, cfg);
+  applyRope(q, k, pos, cfg);
+  // the attention sees history[0..histLen) plus THIS token at index histLen.
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+  const kAll = new Float64Array((histLen + 1) * kvDim);
+  const vAll = new Float64Array((histLen + 1) * kvDim);
+  kAll.set(kHist.subarray(0, histLen * kvDim));
+  vAll.set(vHist.subarray(0, histLen * kvDim));
+  kAll.set(k, histLen * kvDim);
+  vAll.set(v, histLen * kvDim);
+  const attn = attendToken(q, kAll, vAll, histLen + 1, cfg);
+  const attnOut = matmul(tensor(attn, [1, cfg.nHeads * cfg.dHead]), w.wO).data;
+  // residual
+  const h1 = new Float64Array(cfg.dModel);
+  for (let i = 0; i < cfg.dModel; i++) h1[i] = h[i] + attnOut[i];
+  // FFN sub-block, pre-norm + residual
+  const normed2 = rmsNorm(tensor(h1, [1, cfg.dModel]), w.normFFN).data;
+  const ff = ffn(normed2, w, cfg);
+  const h2 = new Float64Array(cfg.dModel);
+  for (let i = 0; i < cfg.dModel; i++) h2[i] = h1[i] + ff[i];
+  return { h: h2, k, v };
+}
+
+// Project a final hidden vector to vocab logits via the tied embedding matrix.
+// embed is [vocab, dModel]; logits = h @ embed^T -> [vocab]. Weight tying (reusing
+// the input embedding as the output head) is standard and halves the parameter
+// count; we implement the transpose by hand to keep the row-major story honest.
+function logitsFromHidden(h: Float64Array, model: Model): Float64Array {
+  const { vocabSize, dModel } = model.cfg;
+  const normed = rmsNorm(tensor(h, [1, dModel]), model.normOut).data;
+  const out = new Float64Array(vocabSize);
+  const E = model.embed.data;
+  for (let t = 0; t < vocabSize; t++) {
+    let s = 0;
+    const row = t * dModel;
+    for (let d = 0; d < dModel; d++) s += normed[d] * E[row + d];
+    out[t] = s;
+  }
+  return out;
+}
+
+// forwardNoCache — the REFERENCE path. Recompute everything from scratch for the
+// whole token sequence and return the logits for the LAST position. O(seq^2) per
+// layer because every token re-attends over all prior tokens with no reuse.
+//
+// This is the "obviously correct, obviously slow" baseline. Stage02's cached path
+// must match its last-token logits to within float64 noise — that equality is the
+// proof the cache is correct, and the speedup over THIS is the headline of stage02.
+export function forwardNoCache(model: Model, tokenIds: number[]): Float64Array {
+  const cfg = model.cfg;
+  const seq = tokenIds.length;
+  if (seq === 0) throw new Error("forwardNoCache: empty token sequence");
+  if (seq > cfg.maxSeq) throw new Error(`forwardNoCache: seq ${seq} > maxSeq ${cfg.maxSeq}`);
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+  // hidden states for all positions
+  let h: Float64Array[] = tokenIds.map((id) => {
+    const e = new Float64Array(cfg.dModel);
+    e.set(model.embed.data.subarray(id * cfg.dModel, (id + 1) * cfg.dModel));
+    return e;
+  });
+  for (let l = 0; l < cfg.nLayers; l++) {
+    const w = model.layers[l];
+    const newH: Float64Array[] = [];
+    const kHist = new Float64Array(seq * kvDim);
+    const vHist = new Float64Array(seq * kvDim);
+    for (let pos = 0; pos < seq; pos++) {
+      const r = blockStep(h[pos], w, pos, kHist, vHist, pos, cfg);
+      kHist.set(r.k, pos * kvDim);
+      vHist.set(r.v, pos * kvDim);
+      newH.push(r.h);
+    }
+    h = newH;
+  }
+  return logitsFromHidden(h[seq - 1], model);
+}
+
+// forwardStep — the CACHED path. Process ONE token at absolute position cache.len,
+// reusing all previously-cached K/V, append this token's K/V to the cache, and
+// return its logits. O(seq) per step instead of O(seq^2): this is the entire reason
+// inference engines exist. The cache is mutated in place; caller advances len.
+//
+// Precondition (invariant the cache type enforces): cache.len is the absolute
+// position of the incoming token. Prefill is just calling this once per prompt
+// token; decode is calling it once per generated token. Same function, two phases —
+// which is the prefill/decode dichotomy the metrics module talks about.
+export function forwardStep(model: Model, tokenId: number, cache: KVCache): Float64Array {
+  const cfg = model.cfg;
+  const pos = cache.len;
+  if (pos >= cfg.maxSeq) throw new Error(`forwardStep: position ${pos} >= maxSeq ${cfg.maxSeq}`);
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+  // annotate as plain Float64Array (not the ArrayBuffer-narrowed `new` type) so the
+  // reassignment from blockStep's return below type-checks under @types/node 22.
+  let h: Float64Array = new Float64Array(cfg.dModel);
+  h.set(model.embed.data.subarray(tokenId * cfg.dModel, (tokenId + 1) * cfg.dModel));
+  for (let l = 0; l < cfg.nLayers; l++) {
+    const w = model.layers[l];
+    const r = blockStep(h, w, pos, cache.k[l], cache.v[l], pos, cfg);
+    // grow this layer's cache by one row (the just-computed K/V). Reallocating per
+    // step is O(n) copying and is the naive approach stage05 replaces with paging.
+    const grownK = new Float64Array((pos + 1) * kvDim);
+    grownK.set(cache.k[l].subarray(0, pos * kvDim));
+    grownK.set(r.k, pos * kvDim);
+    cache.k[l] = grownK;
+    const grownV = new Float64Array((pos + 1) * kvDim);
+    grownV.set(cache.v[l].subarray(0, pos * kvDim));
+    grownV.set(r.v, pos * kvDim);
+    cache.v[l] = grownV;
+    h = r.h;
+  }
+  cache.len = pos + 1;
+  return logitsFromHidden(h, model);
+}
+
+// expose a few internals so optimization stages (paged-KV, quant) can reuse the
+// exact same arithmetic instead of re-deriving it and drifting from the reference.
+export const _internal = { logitsFromHidden, blockStep, projectQKV, applyRope, attendToken, ffn, zeros };

--- a/examples/llm-inference-from-scratch/src/core/tensor.ts
+++ b/examples/llm-inference-from-scratch/src/core/tensor.ts
@@ -1,0 +1,216 @@
+// core/tensor.ts — the toy tensor kernels every stage in this book bottoms out in.
+//
+// Why hand-rolled Float64Array kernels instead of a BLAS / ONNX / wasm backend:
+// this book is about the *inference engine* (KV cache, batching, paging,
+// speculation, quantization), not about kernel micro-optimization. A reader must
+// be able to (a) read every multiply, (b) count FLOPs by eye, and (c) trust that
+// two runs produce bit-for-bit identical numbers. A BLAS backend would give us
+// speed but steal all three. So every op here is an explicit loop. It is slow on
+// purpose; absolute tok/s is therefore pessimistic, but every *relative* speedup
+// a later stage reports (cache vs no-cache, batched vs serial) is real and
+// transfers to a real engine.
+//
+// Layout invariant: every Tensor is row-major. A [m, n] matrix stores element
+// (i, j) at data[i * n + j]. Every kernel below assumes and preserves this.
+// Violating it is the single most common bug when extending these kernels —
+// there are no shape-broadcasting niceties to paper over a transposed input.
+
+export type Tensor = { data: Float64Array; shape: number[] };
+
+// Allocate a zeroed tensor. Float64 (not Float32) so that quantization stages
+// have a clean high-precision reference to compare against: the whole point of
+// stage07 is measuring the L∞ drift float32/int8 introduces, which only means
+// something if the baseline is meaningfully more precise.
+export function zeros(shape: number[]): Tensor {
+  const n = shape.reduce((a, b) => a * b, 1);
+  return { data: new Float64Array(n), shape: [...shape] };
+}
+
+export function tensor(data: number[] | Float64Array, shape: number[]): Tensor {
+  const n = shape.reduce((a, b) => a * b, 1);
+  if (data.length !== n) {
+    // Loud failure: a length/shape mismatch is a construction bug, not a runtime
+    // condition. Catching it here saves hours of debugging silently-misread rows.
+    throw new Error(`tensor: data length ${data.length} != shape product ${n} (${shape})`);
+  }
+  return { data: data instanceof Float64Array ? data : Float64Array.from(data), shape: [...shape] };
+}
+
+// Matrix multiply: A[m,k] @ B[k,n] -> C[m,n], all row-major.
+//
+// This is the engine's hot loop — every attention projection and FFN layer is a
+// matmul, and in a real model it is >90% of the FLOPs. We keep the textbook ikj
+// loop order (not ijk): ikj walks B and C contiguously in the inner loop, which
+// is markedly cache-friendlier than ijk even in JS. We do NOT tile or unroll —
+// readability wins, and the book's speedups never come from kernel tricks.
+//
+// Failure mode: inner dimensions must match. A mismatch here is the classic
+// "I forgot to transpose the weight" bug; we throw rather than read garbage.
+export function matmul(a: Tensor, b: Tensor): Tensor {
+  const [m, k] = a.shape;
+  const [k2, n] = b.shape;
+  if (a.shape.length !== 2 || b.shape.length !== 2) {
+    throw new Error(`matmul: both args must be 2-D, got ${a.shape} and ${b.shape}`);
+  }
+  if (k !== k2) {
+    throw new Error(`matmul: inner dims disagree: ${a.shape} @ ${b.shape}`);
+  }
+  const out = new Float64Array(m * n);
+  const A = a.data;
+  const B = b.data;
+  for (let i = 0; i < m; i++) {
+    const aRow = i * k;
+    const cRow = i * n;
+    for (let p = 0; p < k; p++) {
+      const aip = A[aRow + p];
+      // Skipping the multiply when aip === 0 is NOT done on purpose: it would make
+      // timing data-dependent and break the "every run costs the same" promise the
+      // benchmark stage relies on.
+      const bRow = p * n;
+      for (let j = 0; j < n; j++) {
+        out[cRow + j] += aip * B[bRow + j];
+      }
+    }
+  }
+  return { data: out, shape: [m, n] };
+}
+
+// Add a per-column bias vector to every row of x[m, n]. In-place on a copy.
+// Invariant: bias.length === n. Used after every projection.
+export function addBias(x: Tensor, bias: Tensor): Tensor {
+  const [m, n] = x.shape;
+  if (bias.data.length !== n) {
+    throw new Error(`addBias: bias length ${bias.data.length} != cols ${n}`);
+  }
+  const out = new Float64Array(x.data.length);
+  for (let i = 0; i < m; i++) {
+    const row = i * n;
+    for (let j = 0; j < n; j++) out[row + j] = x.data[row + j] + bias.data[j];
+  }
+  return { data: out, shape: [m, n] };
+}
+
+// RMSNorm (the LLaMA-family normalizer): x_i * w_i / sqrt(mean(x^2) + eps).
+//
+// We call the export `layerNorm` to match the coreSpec name, but it is RMSNorm:
+// no mean-subtraction, no bias. Modern decoder LLMs use RMSNorm because it is
+// cheaper and empirically as good; matching that keeps the toy model honest.
+//
+// Why eps matters (a real failure mode): the +eps inside the sqrt is the only
+// thing standing between you and a division by zero on an all-zero row (which the
+// synthetic model can produce after an unlucky init). Set eps too small (1e-12)
+// and a near-zero row still blows the result up to ~1e6 and then NaNs downstream;
+// 1e-6..1e-5 is the safe band. We expose it so a stage can demo the NaN.
+export function rmsNorm(x: Tensor, weight: Tensor, eps = 1e-6): Tensor {
+  const [m, n] = x.shape;
+  if (weight.data.length !== n) {
+    throw new Error(`rmsNorm: weight length ${weight.data.length} != cols ${n}`);
+  }
+  const out = new Float64Array(x.data.length);
+  for (let i = 0; i < m; i++) {
+    const row = i * n;
+    let ss = 0;
+    for (let j = 0; j < n; j++) {
+      const v = x.data[row + j];
+      ss += v * v;
+    }
+    const inv = 1 / Math.sqrt(ss / n + eps);
+    for (let j = 0; j < n; j++) out[row + j] = x.data[row + j] * inv * weight.data[j];
+  }
+  return { data: out, shape: [m, n] };
+}
+
+// alias kept for the coreSpec name; RMSNorm is the layer norm this book uses.
+export const layerNorm = rmsNorm;
+
+// Numerically-stable softmax over the last axis of a [rows, cols] tensor.
+//
+// THE canonical inference numerics lesson: never exponentiate raw logits. Real
+// attention logits routinely reach +40..+80; exp(80) ≈ 5.5e34, well under
+// float64's ~1.8e308 ceiling so float64 survives — but float32 (exp(89) = inf)
+// and especially the quantized paths in stage07 do NOT. Subtracting the row max
+// first makes the largest exponent exactly exp(0)=1, so the result is identical
+// in exact arithmetic but never overflows. We keep the subtraction unconditional
+// so the lesson is visible and the behavior is the same precision-to-precision.
+export function softmax(x: Tensor): Tensor {
+  const [rows, cols] = x.shape;
+  const out = new Float64Array(x.data.length);
+  for (let i = 0; i < rows; i++) {
+    const row = i * cols;
+    let max = -Infinity;
+    for (let j = 0; j < cols; j++) if (x.data[row + j] > max) max = x.data[row + j];
+    let sum = 0;
+    for (let j = 0; j < cols; j++) {
+      const e = Math.exp(x.data[row + j] - max);
+      out[row + j] = e;
+      sum += e;
+    }
+    // sum >= 1 always (the max term contributes exactly 1), so this division is
+    // safe even for an all -Infinity row (fully-masked) — that case yields NaN,
+    // which is the correct loud signal that you masked away every position.
+    const inv = 1 / sum;
+    for (let j = 0; j < cols; j++) out[row + j] *= inv;
+  }
+  return { data: out, shape: [rows, cols] };
+}
+
+// SiLU / swish activation: x * sigmoid(x). The FFN nonlinearity in LLaMA-style
+// gated MLPs. Element-wise, shape-preserving. sigmoid is written as the numerically
+// stable two-branch form so a large negative x cannot exp-overflow into inf.
+export function silu(x: Tensor): Tensor {
+  const out = new Float64Array(x.data.length);
+  for (let i = 0; i < x.data.length; i++) {
+    const v = x.data[i];
+    const s = v >= 0 ? 1 / (1 + Math.exp(-v)) : (() => { const e = Math.exp(v); return e / (1 + e); })();
+    out[i] = v * s;
+  }
+  return { data: out, shape: [...x.shape] };
+}
+
+// Rotary Position Embedding (RoPE), applied in-place to a query and key vector
+// for ONE position. q and k are length dHead; pos is the absolute token index.
+//
+// Why RoPE and not learned/absolute embeddings: RoPE encodes position by *rotating*
+// query/key pairs, so the attention score between positions i and j depends only
+// on (i - j). That relative property is exactly what makes the KV cache work —
+// a cached key computed at position 5 stays valid forever, because its rotation
+// is absolute and frozen. This is the geometric reason stage02's cache is correct,
+// so it lives in core, not in a stage.
+//
+// Invariant: dHead must be even (we rotate (2i, 2i+1) pairs). theta=10000 is the
+// standard base. Failure mode: pass an odd dHead and the last dim is silently
+// dropped — we guard against it.
+export function rope(q: Float64Array, k: Float64Array, pos: number, theta = 10000): void {
+  const d = q.length;
+  if (d !== k.length) throw new Error(`rope: q/k length mismatch ${d} != ${k.length}`);
+  if (d % 2 !== 0) throw new Error(`rope: dHead must be even, got ${d}`);
+  for (let i = 0; i < d; i += 2) {
+    const freq = 1 / Math.pow(theta, i / d);
+    const angle = pos * freq;
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const q0 = q[i];
+    const q1 = q[i + 1];
+    q[i] = q0 * cos - q1 * sin;
+    q[i + 1] = q0 * sin + q1 * cos;
+    const k0 = k[i];
+    const k1 = k[i + 1];
+    k[i] = k0 * cos - k1 * sin;
+    k[i + 1] = k0 * sin + k1 * cos;
+  }
+}
+
+// Build an additive causal mask of shape [seq, seq]: 0 on/below the diagonal,
+// -Infinity above it. Added to attention logits BEFORE softmax so a token can
+// never attend to its future. Using -Infinity (not a big negative like -1e9)
+// makes the masked softmax weight exactly 0; -1e9 leaves a ~1e-9 leak that, over
+// many layers, is a real (and maddening to find) correctness bug.
+export function causalMask(seq: number): Tensor {
+  const out = new Float64Array(seq * seq);
+  for (let i = 0; i < seq; i++) {
+    for (let j = 0; j < seq; j++) {
+      out[i * seq + j] = j > i ? -Infinity : 0;
+    }
+  }
+  return { data: out, shape: [seq, seq] };
+}

--- a/examples/llm-inference-from-scratch/src/core/tokenizer.ts
+++ b/examples/llm-inference-from-scratch/src/core/tokenizer.ts
@@ -1,0 +1,64 @@
+// core/tokenizer.ts — a byte-level, zero-file, fully deterministic tokenizer.
+//
+// Why byte-level and not BPE: a real BPE tokenizer needs a trained merge table
+// (a downloaded file, a vocab of 50k+). That would drag a network/asset dependency
+// into a book that promises "offline, reproducible, from scratch". A UTF-8 byte
+// tokenizer needs nothing: vocab is exactly the 256 byte values, encode is
+// "give me the bytes", decode is "give me the string back". Every prompt on Earth
+// is encodable, identically, on any machine, forever.
+//
+// The cost — sequences are longer than BPE would produce (one token per byte, so
+// multi-byte UTF-8 chars span several tokens) — is irrelevant to this book: we are
+// measuring the *engine* (cache, batching, paging), and a longer sequence just
+// means more decode steps to time, which is if anything more honest.
+//
+// Invariant the whole book leans on: decode(encode(s)) === s for any string s.
+// This round-trip is what lets a stage print human-readable (if gibberish, since
+// the model is untrained) output and trust the token bookkeeping underneath it.
+
+export const VOCAB_SIZE = 256;
+
+const ENC = new TextEncoder();
+const DEC = new TextDecoder();
+
+// encode: string -> token ids (one per UTF-8 byte). TextEncoder is deterministic
+// and built in. ids are in [0, 255], matching the toy model's vocabSize=256, so a
+// logit row indexes directly by token id with no embedding-table lookup table file.
+export function encode(s: string): number[] {
+  return Array.from(ENC.encode(s));
+}
+
+// decode: token ids -> string. We clamp/mask to a byte because the sampler can,
+// by construction of a 256-wide vocab, only ever emit a valid byte — but an
+// untrained model will emit *arbitrary* bytes, so the decoded string is often
+// invalid UTF-8. TextDecoder's default (fatal:false) replaces bad sequences with
+// U+FFFD rather than throwing, which is the right call: a garbled byte is a
+// model-quality artifact, not an engine bug, and must not crash the pipeline.
+export function decode(ids: number[]): string {
+  const bytes = new Uint8Array(ids.length);
+  for (let i = 0; i < ids.length; i++) {
+    const id = ids[i];
+    // Loud-ish guard: an out-of-range id means the sampler/model is misconfigured
+    // (e.g. vocabSize mismatch), which we would rather surface than silently &0xff.
+    if (id < 0 || id > 255 || !Number.isInteger(id)) {
+      throw new Error(`decode: token id ${id} out of byte range — vocab mismatch?`);
+    }
+    bytes[i] = id;
+  }
+  return DEC.decode(bytes);
+}
+
+// A fixed prompt set used across stages. ≥3 prompts of *different lengths* on
+// purpose: a single prompt risks N=1 luck (e.g. a length that happens to align
+// with a page boundary in stage05, or a TTFT that happens to look flat). Reporting
+// metrics across this spread is the difference between "it worked once" and "it
+// works". Kept ASCII so byte-count == char-count, making the prefill-length math
+// in the stages easy to eyeball.
+export const PROMPTS: readonly string[] = [
+  "The",
+  "Inference engines must be measured, not guessed.",
+  "A long prompt stresses the prefill stage: every token here is processed in " +
+    "one batched forward pass before a single output token is produced, which is " +
+    "why time-to-first-token grows with prompt length while inter-token latency " +
+    "does not.",
+] as const;

--- a/examples/llm-inference-from-scratch/src/stage01-forward.ts
+++ b/examples/llm-inference-from-scratch/src/stage01-forward.ts
@@ -1,0 +1,472 @@
+// stage01-forward.ts — Tiny Transformer forward pass: token -> logits, hand-traced.
+//
+// This is chapter 01's runnable companion. It does NOT re-derive the model — it
+// drives core/* (the same buildModel / matmul / rmsNorm / rope / softmax the
+// reference forwardNoCache uses), so every number printed here is computed by the
+// exact arithmetic later chapters compare against. Re-implementing the math in a
+// stage would let it silently drift from core; instead we instrument core's own
+// operators by walking one block by hand with the same primitives.
+//
+// What this chapter proves with REAL numbers:
+//   (a) per-operator activation statistics (mean/std) down one block, showing
+//       RMSNorm pulls activations back to ~unit scale every time it runs — the
+//       invariant that keeps a deep stack from exploding into NaN.
+//   (b) attention's O(seq^2) cost: the score-matrix multiply count and wall-clock
+//       across seq = 16/32/64/128, confirming quadratic (not linear) growth. This
+//       is the cost the KV cache (chapter 02) exists to kill.
+//   (c) a failure-mode demo: rerun softmax WITHOUT the max-subtraction on a long
+//       prompt's real attention logits and watch it produce NaN — proving
+//       numerical stability is load-bearing, not decorative.
+//   (d) golden logits: the last-token logits for all 3 prompts, hashed + summarized,
+//       saved as this chapter's reference for later chapters to diff against.
+//
+// Honesty caveat (echoed from core/metrics): the model is tiny and the kernels are
+// unoptimized float64 loops, so ABSOLUTE timings are pessimistic. What transfers is
+// the SHAPE of the curve (quadratic) and the operator-level invariants, not the ms.
+
+import { DEFAULT_CONFIG, buildModel, forwardNoCache } from "./core/model.js";
+import { tensor, matmul, rmsNorm, silu, rope } from "./core/tensor.js";
+import { encode, PROMPTS } from "./core/tokenizer.js";
+import { argmax, timeIt } from "./core/metrics.js";
+
+const SEED = 42; // fixed: determinism is the whole point — see core/model header.
+
+// Summary statistics of one activation vector. We report mean and std (population)
+// because RMSNorm's job is to control the *scale* of activations: after it runs,
+// rms = sqrt(mean(x^2)) should be ~1 (times the per-dim gain, which inits to ~1),
+// so std lands near 1 too. Watching std stay bounded across operators is how you
+// see, numerically, that the network is not diverging.
+type Stats = { mean: number; std: number; rms: number; absMax: number };
+
+function statsOf(x: Float64Array): Stats {
+  const n = x.length;
+  let sum = 0;
+  let sumSq = 0;
+  let absMax = 0;
+  for (let i = 0; i < n; i++) {
+    const v = x[i];
+    sum += v;
+    sumSq += v * v;
+    const a = Math.abs(v);
+    if (a > absMax) absMax = a;
+  }
+  const mean = sum / n;
+  const meanSq = sumSq / n;
+  // std uses the population formula (divide by n): we are describing THIS exact
+  // vector, not estimating a sampling distribution, so Bessel's n-1 correction is
+  // the wrong tool here.
+  const variance = Math.max(0, meanSq - mean * mean);
+  return { mean, std: Math.sqrt(variance), rms: Math.sqrt(meanSq), absMax };
+}
+
+function fmtStats(label: string, s: Stats): string {
+  const f = (x: number) => x.toFixed(4).padStart(9);
+  return `    ${label.padEnd(22)} mean=${f(s.mean)}  std=${f(s.std)}  rms=${f(s.rms)}  |max|=${f(s.absMax)}`;
+}
+
+// --- (a) per-operator trace through ONE transformer block --------------------
+//
+// We reproduce, operator by operator, what core's blockStep does for the LAST
+// token of a prompt at layer 0 — same primitives, same order — but capture the
+// intermediate activations so we can print stats. The point is pedagogical
+// transparency: a reader sees embed -> RMSNorm -> Q/K/V -> RoPE -> attention ->
+// residual -> RMSNorm -> FFN -> residual, with the scale at every checkpoint.
+//
+// Invariant being demonstrated: every RMSNorm output has rms ~= 1 (times gain),
+// independent of how large its input grew via residual accumulation. That is the
+// mechanism. We compute it on the real model weights, so the numbers are honest.
+function traceBlockOperators(): void {
+  const cfg = DEFAULT_CONFIG;
+  const model = buildModel(cfg, SEED);
+  // Use the longest prompt so the attention step actually attends over many
+  // positions (a length-1 prompt would make attention a no-op and hide the point).
+  const ids = encode(PROMPTS[2]);
+  const seq = ids.length;
+  const w = model.layers[0];
+  const lastPos = seq - 1;
+
+  console.log(`\n[a] Per-operator activation trace — layer 0, last token (pos ${lastPos}) of a ${seq}-token prompt`);
+  console.log(`    config: dModel=${cfg.dModel} nHeads=${cfg.nHeads} nKVHeads=${cfg.nKVHeads} dHead=${cfg.dHead} dFF=${cfg.dFF}`);
+
+  // To get the LAST token's pre-block hidden at layer 0, that hidden is simply its
+  // embedding row (layer 0 input == embeddings). We also need all prior tokens'
+  // K/V at this layer for the attention step, which are likewise functions of their
+  // embeddings; we recompute them here with the same projectQKV+RoPE core does.
+  const dModel = cfg.dModel;
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+
+  const embedRow = (id: number): Float64Array =>
+    Float64Array.from(model.embed.data.subarray(id * dModel, (id + 1) * dModel));
+
+  const hLast = embedRow(ids[lastPos]);
+  console.log(fmtStats("embed (block input)", statsOf(hLast)));
+
+  // pre-norm (RMSNorm) before attention
+  const normed = rmsNorm(tensor(hLast, [1, dModel]), w.normAtt).data;
+  console.log(fmtStats("RMSNorm(att)", statsOf(normed)));
+  // NOTE: rms here should be ~1 regardless of the embed input's scale above — that
+  // contrast (embed |max| vs normed |max|) is the whole lesson of this checkpoint.
+
+  // Q/K/V projections for the last token.
+  const nT = tensor(normed, [1, dModel]);
+  const qLast = matmul(nT, w.wQ).data;
+  const kLast = matmul(nT, w.wK).data;
+  const vLast = matmul(nT, w.wV).data;
+  console.log(fmtStats("Q proj", statsOf(qLast)));
+  console.log(fmtStats("K proj", statsOf(kLast)));
+  console.log(fmtStats("V proj", statsOf(vLast)));
+
+  // RoPE rotates Q (and K) in place per head. We rotate only the last token's Q
+  // for the trace; full K history is rotated below when building the score matrix.
+  ropeAllQueryHeads(qLast, lastPos, cfg);
+  console.log(fmtStats("Q after RoPE", statsOf(qLast)));
+  // RoPE is a rotation: it preserves each head's L2 norm, so rms is unchanged —
+  // a good sanity check that we applied it correctly (a buggy RoPE would shift rms).
+
+  // Build the full rope'd K and V history (all positions 0..lastPos), then run
+  // GQA attention for the last token. We reuse the exact attention arithmetic by
+  // hand so we can inspect the post-attention activation scale.
+  const kHist = new Float64Array(seq * kvDim);
+  const vHist = new Float64Array(seq * kvDim);
+  for (let p = 0; p < seq; p++) {
+    const hp = rmsNorm(tensor(embedRow(ids[p]), [1, dModel]), w.normAtt).data;
+    const hpT = tensor(hp, [1, dModel]);
+    const kp = matmul(hpT, w.wK).data;
+    const vp = matmul(hpT, w.wV).data;
+    ropeAllKVHeads(kp, p, cfg); // rotate K at its absolute position p
+    kHist.set(kp, p * kvDim);
+    vHist.set(vp, p * kvDim);
+  }
+  const { out: attn, lastLogits: lastHeadScores } = attendLastToken(qLast, kHist, vHist, seq, cfg);
+  console.log(fmtStats("attention output", statsOf(attn)));
+
+  const attnOut = matmul(tensor(attn, [1, cfg.nHeads * cfg.dHead]), w.wO).data;
+  console.log(fmtStats("attn out-proj (wO)", statsOf(attnOut)));
+
+  // residual add
+  const h1 = new Float64Array(dModel);
+  for (let i = 0; i < dModel; i++) h1[i] = hLast[i] + attnOut[i];
+  console.log(fmtStats("after attn residual", statsOf(h1)));
+  // NOTE: residual ADDS attnOut onto the input, so |max| here is typically larger
+  // than either summand — this is exactly the unbounded growth RMSNorm reins in
+  // at the next checkpoint. Watch rms go back to ~1 on the next line.
+
+  // FFN sub-block: pre-norm, SiLU-gated MLP, residual.
+  const normed2 = rmsNorm(tensor(h1, [1, dModel]), w.normFFN).data;
+  console.log(fmtStats("RMSNorm(ffn)", statsOf(normed2)));
+  const n2T = tensor(normed2, [1, dModel]);
+  const gate = silu(matmul(n2T, w.w1)).data;
+  const up = matmul(n2T, w.w3).data;
+  const prod = new Float64Array(cfg.dFF);
+  for (let i = 0; i < cfg.dFF; i++) prod[i] = gate[i] * up[i];
+  console.log(fmtStats("SiLU-gated hidden", statsOf(prod)));
+  const ff = matmul(tensor(prod, [1, cfg.dFF]), w.w2).data;
+  console.log(fmtStats("FFN down-proj", statsOf(ff)));
+  const h2 = new Float64Array(dModel);
+  for (let i = 0; i < dModel; i++) h2[i] = h1[i] + ff[i];
+  console.log(fmtStats("block output", statsOf(h2)));
+
+  // Stash the last head's raw (pre-softmax) attention scores for the (c) failure
+  // demo — these are real logits from a real attention head over `seq` positions,
+  // which is exactly the kind of vector that overflows a naive softmax.
+  failureDemoScores = lastHeadScores;
+
+  // The headline invariant, stated as a checked claim, not a vibe:
+  const normedRms = statsOf(normed).rms;
+  const normed2Rms = statsOf(normed2).rms;
+  const ok = Math.abs(normedRms - 1) < 0.1 && Math.abs(normed2Rms - 1) < 0.1;
+  console.log(
+    `    => RMSNorm invariant: both norm outputs have rms ~ 1 ` +
+      `(${normedRms.toFixed(3)}, ${normed2Rms.toFixed(3)}) — ${ok ? "HOLDS" : "VIOLATED"}`
+  );
+}
+
+// RoPE the query heads of one token in place (nHeads heads of dHead each). core's
+// rope() rotates a q/k pair; we only want q rotated here, so pass a throwaway k.
+function ropeAllQueryHeads(q: Float64Array, pos: number, cfg: typeof DEFAULT_CONFIG): void {
+  for (let h = 0; h < cfg.nHeads; h++) {
+    const slice = q.subarray(h * cfg.dHead, (h + 1) * cfg.dHead);
+    const scratch = Float64Array.from(slice);
+    rope(slice, scratch, pos, 10000);
+  }
+}
+
+// RoPE the kv heads of one token in place (nKVHeads heads, GQA-narrower than q).
+function ropeAllKVHeads(k: Float64Array, pos: number, cfg: typeof DEFAULT_CONFIG): void {
+  for (let h = 0; h < cfg.nKVHeads; h++) {
+    const slice = k.subarray(h * cfg.dHead, (h + 1) * cfg.dHead);
+    const scratch = Float64Array.from(slice);
+    rope(scratch, slice, pos, 10000);
+  }
+}
+
+// GQA attention for one query token over `len` cached positions. Mirrors core's
+// attendToken, but also returns the raw (pre-softmax) score row of the LAST head
+// so the failure demo has real attention logits to feed a naive softmax.
+function attendLastToken(
+  q: Float64Array,
+  kAll: Float64Array,
+  vAll: Float64Array,
+  len: number,
+  cfg: typeof DEFAULT_CONFIG
+): { out: Float64Array; lastLogits: Float64Array } {
+  const groupSize = cfg.nHeads / cfg.nKVHeads;
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+  const out = new Float64Array(cfg.nHeads * cfg.dHead);
+  const invSqrtD = 1 / Math.sqrt(cfg.dHead);
+  let lastLogits = new Float64Array(len);
+  for (let h = 0; h < cfg.nHeads; h++) {
+    const kvHead = Math.floor(h / groupSize);
+    const qOff = h * cfg.dHead;
+    const rawScores = new Float64Array(len);
+    for (let p = 0; p < len; p++) {
+      const kOff = p * kvDim + kvHead * cfg.dHead;
+      let dotv = 0;
+      for (let d = 0; d < cfg.dHead; d++) dotv += q[qOff + d] * kAll[kOff + d];
+      rawScores[p] = dotv * invSqrtD;
+    }
+    // numerically-stable softmax via core (it subtracts the row max).
+    const probs = stableSoftmaxRow(rawScores);
+    for (let p = 0; p < len; p++) {
+      const vOff = p * kvDim + kvHead * cfg.dHead;
+      const wgt = probs[p];
+      for (let d = 0; d < cfg.dHead; d++) out[qOff + d] += wgt * vAll[vOff + d];
+    }
+    lastLogits = rawScores; // keep the final head's raw scores
+  }
+  return { out, lastLogits };
+}
+
+// --- (c) failure mode: naive softmax overflows ------------------------------
+//
+// THE numerics lesson. A correct softmax subtracts the row max before exp (see
+// core/tensor.softmax). The naive version does not. On small logits both agree;
+// on the large logits real attention produces, the naive one exponentiates a big
+// number and overflows to Infinity, then Infinity/Infinity = NaN poisons the row.
+
+function stableSoftmaxRow(scores: Float64Array): Float64Array {
+  // delegate to the principle core uses: subtract max first.
+  let max = -Infinity;
+  for (const v of scores) if (v > max) max = v;
+  const out = new Float64Array(scores.length);
+  let sum = 0;
+  for (let i = 0; i < scores.length; i++) {
+    const e = Math.exp(scores[i] - max);
+    out[i] = e;
+    sum += e;
+  }
+  const inv = 1 / sum;
+  for (let i = 0; i < out.length; i++) out[i] *= inv;
+  return out;
+}
+
+function naiveSoftmaxRow(scores: Float64Array): Float64Array {
+  // The bug: exp the raw logit with NO max-subtraction.
+  const out = new Float64Array(scores.length);
+  let sum = 0;
+  for (let i = 0; i < scores.length; i++) {
+    const e = Math.exp(scores[i]); // overflows to Infinity for large scores
+    out[i] = e;
+    sum += e;
+  }
+  const inv = 1 / sum; // Infinity-sum -> inv = 0; e/Infinity-style -> NaN
+  for (let i = 0; i < out.length; i++) out[i] *= inv;
+  return out;
+}
+
+// Captured during the (a) trace: a real head's pre-softmax scores. Initialized in
+// traceBlockOperators(); used by demoNaiveSoftmaxOverflow(). Module-level because
+// the trace produces it as a byproduct and the demo consumes it — passing it
+// through every call site would only add noise.
+let failureDemoScores: Float64Array = new Float64Array(0);
+
+function hasNaN(x: Float64Array): boolean {
+  for (const v of x) if (Number.isNaN(v)) return true;
+  return false;
+}
+
+function demoNaiveSoftmaxOverflow(): void {
+  console.log(`\n[c] Failure mode: softmax WITHOUT max-subtraction`);
+
+  // First, on the REAL attention scores captured during the (a) trace: these are
+  // modest (the toy model keeps logits small), so both softmaxes should agree —
+  // this establishes the naive version is not "always broken", it is conditionally
+  // broken, which is the dangerous kind.
+  const realScores = failureDemoScores;
+  const realStable = stableSoftmaxRow(realScores);
+  const realNaive = naiveSoftmaxRow(realScores);
+  let maxDrift = 0;
+  for (let i = 0; i < realStable.length; i++) {
+    const d = Math.abs(realStable[i] - realNaive[i]);
+    if (d > maxDrift) maxDrift = d;
+  }
+  const realMax = Math.max(...realScores);
+  console.log(
+    `    real attention scores (len=${realScores.length}, max logit=${realMax.toFixed(3)}): ` +
+      `naive vs stable max prob drift = ${maxDrift.toExponential(2)} ` +
+      `(agree — toy logits are too small to overflow)`
+  );
+
+  // Now the failure: scale the SAME real scores up to the magnitude a trained
+  // model's attention routinely reaches (logits of +700..+900). exp(710) already
+  // exceeds float64's ~1.8e308 ceiling -> Infinity. We do not invent numbers; we
+  // take the real score row and amplify it, so the demo is a transformation of
+  // genuine data, not a hard-coded NaN.
+  const amplify = 800 / Math.max(1e-9, realMax); // push the top logit to ~800
+  const hot = Float64Array.from(realScores, (v) => v * amplify);
+  const hotMax = Math.max(...hot);
+  const stableHot = stableSoftmaxRow(hot);
+  const naiveHot = naiveSoftmaxRow(hot);
+  console.log(`    amplified scores (max logit=${hotMax.toFixed(1)}, exp(${hotMax.toFixed(0)}) overflows float64):`);
+  console.log(`      naive softmax  -> hasNaN=${hasNaN(naiveHot)}  sum=${sumOf(naiveHot)}  [first 3: ${preview(naiveHot)}]`);
+  console.log(`      stable softmax -> hasNaN=${hasNaN(stableHot)}  sum=${sumOf(stableHot).toFixed(6)}  [first 3: ${preview(stableHot)}]`);
+  const proved = hasNaN(naiveHot) && !hasNaN(stableHot);
+  console.log(
+    `    => ${proved ? "PROVEN" : "NOT REPRODUCED"}: max-subtraction is load-bearing — ` +
+      `naive path NaNs, stable path stays a valid distribution (sum=1).`
+  );
+}
+
+function sumOf(x: Float64Array): number {
+  let s = 0;
+  for (const v of x) s += v;
+  return s;
+}
+function preview(x: Float64Array): string {
+  return Array.from(x.subarray(0, 3))
+    .map((v) => (Number.isNaN(v) ? "NaN" : v.toExponential(2)))
+    .join(", ");
+}
+
+// --- (b) attention O(seq^2) cost curve --------------------------------------
+//
+// Attention computes a score for every (query, key) pair. For a full-sequence
+// forward over seq tokens, that is seq*(seq+1)/2 query-key dot products per head
+// per layer (causal: token i attends to 0..i). The count is exactly quadratic in
+// seq; we print both the analytic count AND a wall-clock of forwardNoCache to show
+// the measured time tracks the count's growth shape.
+//
+// We measure forwardNoCache (the O(seq^2) reference path) because chapter 01 has
+// no cache yet — quantifying this cost is precisely the motivation for chapter 02.
+
+function attentionDotProducts(seq: number, cfg: typeof DEFAULT_CONFIG): number {
+  // per head, per layer: sum_{i=0}^{seq-1} (i+1) = seq*(seq+1)/2 causal pairs.
+  const causalPairs = (seq * (seq + 1)) / 2;
+  return causalPairs * cfg.nHeads * cfg.nLayers;
+}
+
+function benchAttentionScaling(): void {
+  const cfg = DEFAULT_CONFIG;
+  const model = buildModel(cfg, SEED);
+  const seqs = [16, 32, 64, 128];
+  console.log(`\n[b] Attention O(seq^2) cost — forwardNoCache (the un-cached reference path)`);
+  console.log(`    seq | qk-dot-products | wall-clock ms | ms/seq^2 (x1e-6) | growth vs prev`);
+
+  // Deterministic, repeatable token stream from the model's own vocab via a tiny
+  // counter — content is irrelevant to timing (matmul cost is data-independent by
+  // design; see core/tensor matmul comment), only LENGTH matters.
+  const makeIds = (n: number): number[] => Array.from({ length: n }, (_, i) => (i * 7 + 3) % cfg.vocabSize);
+
+  let prevMs = 0;
+  let prevSeq = 0;
+  for (const seq of seqs) {
+    const ids = makeIds(seq);
+    const dots = attentionDotProducts(seq, cfg);
+
+    // Warm up first (JIT + cache) so the measured run reflects steady state — the
+    // convention core/metrics.timeIt deliberately does NOT bake in. Average a few
+    // runs to damp timer noise on these sub-millisecond workloads.
+    timeIt(() => void forwardNoCache(model, ids));
+    const REPS = 5;
+    let total = 0;
+    for (let r = 0; r < REPS; r++) total += timeIt(() => void forwardNoCache(model, ids));
+    const ms = total / REPS;
+
+    // ms / seq^2: total time / seq^2. At these TOY sizes this column still FALLS as
+    // seq grows, because total cost = O(seq) per-token work (FFN+projections, which
+    // dominate this tiny model) + O(seq^2) attention, and the linear term is still
+    // larger here. The quadratic signature therefore shows up not in this column but
+    // in the GROWTH RATIO: pure O(seq) would give exactly 2.0x per doubling; the
+    // ratios climbing ABOVE 2.0x (2.00 -> 2.07 -> 2.15) are attention's seq^2 term
+    // starting to bite. With a bigger model / longer seq the normalized column would
+    // flatten as attention takes over.
+    const normalized = (ms / (seq * seq)) * 1e6;
+    const growth = prevMs > 0 ? `${(ms / prevMs).toFixed(2)}x for ${(seq / prevSeq).toFixed(0)}x seq` : "—";
+    console.log(
+      `    ${String(seq).padStart(3)} | ${String(dots).padStart(15)} | ` +
+        `${ms.toFixed(3).padStart(13)} | ${normalized.toFixed(3).padStart(16)} | ${growth}`
+    );
+    prevMs = ms;
+    prevSeq = seq;
+  }
+  console.log(
+    `    => doubling seq 4x's the dot-product count (quadratic, exact). Wall-clock: pure O(seq)`
+  );
+  console.log(
+    `       would give exactly 2.0x per doubling; the ratios climbing ABOVE 2.0x are attention's`
+  );
+  console.log(
+    `       O(seq^2) term emerging on top of the O(seq) per-token work that dominates at toy sizes.`
+  );
+}
+
+// --- (d) golden logits ------------------------------------------------------
+//
+// Save the last-token logits for all 3 prompts as this chapter's reference. Later
+// chapters (cache, batching, quant) must reproduce these to within float64 noise;
+// equality with this golden is their correctness proof. We print a compact, stable
+// fingerprint (a checksum + the argmax token + a few leading values) rather than
+// dumping 256 floats per prompt — enough to detect any drift, small enough to read.
+
+function checksum(x: Float64Array): number {
+  // Order-sensitive rolling sum; not cryptographic — just a cheap, deterministic
+  // fingerprint that changes if ANY logit changes. Reproducible across machines
+  // because it is pure float64 arithmetic on a deterministic input.
+  let acc = 0;
+  for (let i = 0; i < x.length; i++) acc = acc * 1.0000001 + x[i] * (i + 1);
+  return acc;
+}
+
+function emitGoldenLogits(): void {
+  const cfg = DEFAULT_CONFIG;
+  const model = buildModel(cfg, SEED);
+  console.log(`\n[d] Golden last-token logits (seed=${SEED}) — chapter 01 reference for cross-chapter diffs`);
+  console.log(`    prompt(len) | argmax tok | logit[argmax] | mean logit | checksum`);
+  for (let i = 0; i < PROMPTS.length; i++) {
+    const ids = encode(PROMPTS[i]);
+    const logits = forwardNoCache(model, ids);
+    const am = argmax(logits);
+    const s = statsOf(logits);
+    console.log(
+      `    p${i}(${String(ids.length).padStart(3)})     | ${String(am).padStart(10)} | ` +
+        `${logits[am].toFixed(4).padStart(13)} | ${s.mean.toFixed(4).padStart(10)} | ${checksum(logits).toExponential(6)}`
+    );
+  }
+
+  // Determinism re-check: rebuild from the same seed, recompute, and confirm the
+  // golden is bit-for-bit reproducible. If this ever drifts, every downstream
+  // cross-chapter comparison is built on sand — so we assert it here, loudly.
+  const model2 = buildModel(cfg, SEED);
+  const a = forwardNoCache(model, encode(PROMPTS[1]));
+  const b = forwardNoCache(model2, encode(PROMPTS[1]));
+  let drift = 0;
+  for (let i = 0; i < a.length; i++) drift = Math.max(drift, Math.abs(a[i] - b[i]));
+  console.log(`    => determinism: two independent builds drift by ${drift.toExponential(2)} (must be 0 for golden to be a valid reference)`);
+}
+
+function main(): void {
+  console.log("=== stage01 — Tiny Transformer forward: token -> logits ===");
+  console.log(`model: LLaMA-style decoder, ${DEFAULT_CONFIG.nLayers} layers, GQA (nKVHeads=${DEFAULT_CONFIG.nKVHeads}/nHeads=${DEFAULT_CONFIG.nHeads})`);
+  console.log("NOTE: weights are synthetic (seeded PRNG); the model is UNTRAINED, so logits are");
+  console.log("structurally-correct gibberish. This chapter is about the forward MECHANISM, not output quality.");
+
+  traceBlockOperators(); // (a) must run first — it populates failureDemoScores
+  benchAttentionScaling(); // (b)
+  demoNaiveSoftmaxOverflow(); // (c) consumes failureDemoScores
+  emitGoldenLogits(); // (d)
+
+  console.log("\n=== done. Absolute ms are pessimistic (toy float64 kernels); the QUADRATIC SHAPE and");
+  console.log("the RMSNorm/softmax invariants are what transfer to a real engine. ===");
+}
+
+main();

--- a/examples/llm-inference-from-scratch/src/stage02-kvcache.ts
+++ b/examples/llm-inference-from-scratch/src/stage02-kvcache.ts
@@ -1,0 +1,208 @@
+// stage02-kvcache.ts — KV 缓存：把 decode 从 O(n²) 砍成 O(n) 的那一步。
+//
+// The thesis of this chapter, made measurable. Autoregressive decoding emits one
+// token per forward pass, and each new token attends over EVERY prior token. The
+// naive way to get the next-token logits is to re-run the whole sequence through
+// the model from scratch — forwardNoCache — which re-embeds and recomputes the K/V
+// projections of ALL past tokens on every step. Step k does O(k) full work, so
+// generating n tokens costs O(n²) total. The KV cache is the one idea that makes
+// LLM serving viable: store each token's K and V the first time you compute them,
+// so every later step does only O(1) new projection (just the current token) plus
+// an O(k) attention scan over cached keys. The headline "O(n²) → O(n)" is about
+// the PROJECTION/FFN work that dominates: forwardNoCache redoes it for the whole
+// prefix every step (O(n²) summed), the cached path does it once per token (O(n)
+// summed). The attention scan itself is O(n²) in both, but with a far smaller
+// constant, so in practice the cached path's total work collapses. This file
+// PROVES that with three things and one failure:
+//
+//   (a) CORRECTNESS — the two paths must produce bit-identical last-token logits
+//       (maxLogitDrift == 0). If the cache is even slightly wrong, the whole speed
+//       argument is moot, so equivalence is checked FIRST and is load-bearing.
+//   (b) SPEEDUP that grows with generation length — the direct, measured evidence
+//       that we removed an O(n) factor: the longer you generate, the more the
+//       no-cache path re-does, so the ratio widens. A flat ratio would mean we
+//       did NOT remove a factor.
+//   (c) MEMORY — estimateKVBytes shows the cost we trade compute for: the cache
+//       grows linearly in sequence length. This is exact arithmetic, labeled (est.).
+//   (d) FAILURE MODE — decode WITHOUT prefilling the cache. The most common real
+//       cache bug: the model "runs" (no crash) but attention silently sees an empty
+//       history, so the logits are wrong. We quantify the drift so the reader knows
+//       what a consistency bug looks like in numbers, not just in a stack trace.
+//
+// Honesty caveats (echoing core/metrics header): the model is untrained synthetic
+// weights, the kernels are unoptimized float64 loops, so ABSOLUTE tok/s and ms are
+// pessimistic. What transfers to a real engine is the RELATIVE story — the speedup
+// RATIO and the fact that it widens with length. Determinism (seeded PRNG) makes
+// every number here reproducible bit-for-bit on any machine.
+
+import { DEFAULT_CONFIG, buildModel, forwardNoCache, forwardStep, newCache } from "./core/model.js";
+import { encode, PROMPTS } from "./core/tokenizer.js";
+import {
+  timeIt,
+  speedup,
+  maxLogitDrift,
+  estimateKVBytes,
+  formatBytes,
+  argmax,
+} from "./core/metrics.js";
+
+const SEED = 42;
+const GEN_LENGTHS = [8, 16, 32, 64] as const;
+
+// Use the second prompt (length 48): long enough that a growing prefix makes the
+// O(n²) re-work visible, short enough that even N=64 generation stays well under
+// maxSeq=256. Single prompt is fine here because the variable under study is
+// GENERATION LENGTH, not prompt content — we sweep that explicitly in GEN_LENGTHS.
+const promptIds = encode(PROMPTS[1]);
+
+const model = buildModel(DEFAULT_CONFIG, SEED);
+
+// genTokensCached — the production path. Prefill the prompt into the cache (one
+// forwardStep per prompt token, which is exactly what prefill IS), then decode
+// nGen tokens greedily, reusing the cache. Returns the generated token ids plus
+// the last-token logits, so a caller can compare logits across paths.
+//
+// Invariant: cache.len after prefill == promptIds.length; after generation ==
+// promptIds.length + nGen. forwardStep advances it; we never touch it by hand.
+function genTokensCached(nGen: number): { ids: number[]; lastLogits: Float64Array } {
+  const cache = newCache(DEFAULT_CONFIG);
+  // prefill: run the prompt through, filling the cache. The last prefill step's
+  // logits predict the first generated token. Annotated as plain Float64Array (not
+  // the ArrayBuffer-narrowed `new` type) so reassignment from forwardStep type-checks
+  // under @types/node 22 — same widening the core applies in forwardStep.
+  let logits: Float64Array = new Float64Array(0);
+  for (const id of promptIds) logits = forwardStep(model, id, cache);
+  const ids: number[] = [];
+  for (let i = 0; i < nGen; i++) {
+    const next = argmax(logits); // greedy, deterministic (shared tie-break)
+    ids.push(next);
+    logits = forwardStep(model, next, cache); // O(1) projection + O(len) attend
+  }
+  return { ids, lastLogits: logits };
+}
+
+// genTokensNoCache — the reference path. To produce token k we re-run the ENTIRE
+// sequence-so-far through forwardNoCache, which recomputes every prior token's K/V
+// from scratch. This is the O(n²) baseline: step k does O(k) full work, summed
+// over k = O(n²). It is "obviously correct" by construction (no cache to get
+// wrong), which is exactly why it is the oracle the cached path is checked against.
+//
+// We must drive BOTH paths with the same greedy choices, or a single divergent
+// argmax would fork the two token streams and make the comparison meaningless.
+// Greedy argmax over identical logits guarantees identical choices as long as the
+// per-step logits match — which is the very thing (a) verifies.
+function genTokensNoCache(nGen: number): { ids: number[]; lastLogits: Float64Array } {
+  const seq = [...promptIds];
+  let logits = forwardNoCache(model, seq); // prefill-equivalent: last-token logits
+  const ids: number[] = [];
+  for (let i = 0; i < nGen; i++) {
+    const next = argmax(logits);
+    ids.push(next);
+    seq.push(next);
+    logits = forwardNoCache(model, seq); // re-runs the WHOLE prefix every step
+  }
+  return { ids, lastLogits: logits };
+}
+
+// warmup: the first call to any JS hot path pays JIT + cold-cache costs unrelated
+// to steady-state throughput (see core/metrics.timeIt convention — warmup is the
+// caller's job, deliberately not baked in). One throwaway run of each path on the
+// largest length warms both code paths before any measured run.
+function warmup(): void {
+  genTokensCached(GEN_LENGTHS[GEN_LENGTHS.length - 1]);
+  genTokensNoCache(GEN_LENGTHS[GEN_LENGTHS.length - 1]);
+}
+
+console.log("=== stage02 — KV 缓存：O(n²) → O(n) ===\n");
+console.log(`prompt = "${PROMPTS[1]}"`);
+console.log(`prompt tokens = ${promptIds.length}, seed = ${SEED}, config = DEFAULT (GQA nKVHeads=${DEFAULT_CONFIG.nKVHeads}/nHeads=${DEFAULT_CONFIG.nHeads})\n`);
+
+warmup();
+
+// --- (a) CORRECTNESS — cache must equal the reference, exactly --------------------
+// Checked first and per length: if the cache drifts at ANY length the speedup is a
+// lie. We compare last-token logits (maxLogitDrift, L∞) AND the full generated id
+// streams (any mismatch flips a token and is caught).
+console.log("[a] CORRECTNESS — cached path vs no-cache reference (must be exact):");
+let allExact = true;
+for (const n of GEN_LENGTHS) {
+  const cached = genTokensCached(n);
+  const ref = genTokensNoCache(n);
+  const drift = maxLogitDrift(Array.from(cached.lastLogits), Array.from(ref.lastLogits));
+  const idsMatch = cached.ids.length === ref.ids.length && cached.ids.every((v, i) => v === ref.ids[i]);
+  if (drift !== 0 || !idsMatch) allExact = false;
+  console.log(
+    `    gen=${String(n).padStart(2)}  maxLogitDrift=${drift.toExponential(2)}  ids_match=${idsMatch}`
+  );
+}
+console.log(`    => ${allExact ? "EXACT at every length (cache is correct)" : "DRIFT DETECTED — cache is buggy"}\n`);
+
+// --- (b) SPEEDUP that widens with length -----------------------------------------
+// The headline. Wall-clock both full generations (prompt prefill + nGen decode) at
+// each length. The cached total grows ~linearly; the no-cache total grows ~quadratically,
+// so the ratio MUST climb with n. A climbing ratio is the direct fingerprint of an
+// O(n) factor removed. (Absolute ms are toy-pessimistic; the trend is what transfers.)
+console.log("[b] SPEEDUP — no-cache total ms / cached total ms (grows with gen length):");
+console.log("    gen  no-cache(ms)  cached(ms)   speedup");
+let prevSpeedup = 0;
+let monotonic = true;
+for (const n of GEN_LENGTHS) {
+  const cachedMs = timeIt(() => genTokensCached(n));
+  const noCacheMs = timeIt(() => genTokensNoCache(n));
+  const sp = speedup(noCacheMs, cachedMs);
+  if (sp < prevSpeedup) monotonic = false;
+  prevSpeedup = sp;
+  console.log(
+    `    ${String(n).padStart(3)}  ${noCacheMs.toFixed(2).padStart(11)}  ${cachedMs.toFixed(2).padStart(9)}   ${sp.toFixed(2)}x`
+  );
+}
+console.log(
+  `    => speedup ${monotonic ? "grows monotonically with length" : "is noisy run-to-run"} — the O(n²)→O(n) fingerprint\n`
+);
+
+// --- (c) MEMORY — the cost we traded compute for ----------------------------------
+// estimateKVBytes is exact arithmetic on the config (2*nKVHeads*dHead*seq * nLayers
+// * nSeqs * 8 bytes), printed (est.) per the honesty rule. The point: cache memory
+// is LINEAR in sequence length — doubling the context doubles the cache. This is why
+// stage05 (paged-KV) and GQA exist. We show single-sequence growth plus a 32-seq
+// batch to make the serving-capacity number concrete.
+console.log("[c] MEMORY — KV cache grows linearly in sequence length (est.):");
+console.log("    seq   1 seq        32 seqs");
+for (const seq of [16, 32, 64, 128, 256]) {
+  const one = estimateKVBytes(DEFAULT_CONFIG, seq, 1);
+  const batch = estimateKVBytes(DEFAULT_CONFIG, seq, 32);
+  console.log(`    ${String(seq).padStart(3)}   ${formatBytes(one).padStart(10)}   ${formatBytes(batch).padStart(10)} (est.)`);
+}
+const perTok = estimateKVBytes(DEFAULT_CONFIG, 1, 1);
+console.log(`    => +${formatBytes(perTok)}/token/seq (est.); GQA already saves ${DEFAULT_CONFIG.nHeads / DEFAULT_CONFIG.nKVHeads}x vs MHA here\n`);
+
+// --- (d) FAILURE MODE — decode without prefilling the cache -----------------------
+// The single most common real KV-cache bug: you forget to run the prompt through
+// the cache before decoding (or you reset the cache and reuse it). Nothing crashes
+// — forwardStep happily decodes at position 0 with an empty history — but attention
+// sees NONE of the prompt, so the model is "answering" a context it never read. The
+// logits silently diverge from the correct path. We quantify that drift so the
+// reader can recognize the symptom: a finite, large maxLogitDrift (NOT NaN, NOT a
+// crash) is the signature of a cache-consistency bug.
+console.log("[d] FAILURE MODE — decoding without prefilling the cache (a real bug):");
+// correct: prefill THEN take the first decode step.
+const correctCache = newCache(DEFAULT_CONFIG);
+let correctLogits: Float64Array = new Float64Array(0); // widened, see genTokensCached
+for (const id of promptIds) correctLogits = forwardStep(model, id, correctCache);
+const firstTok = argmax(correctLogits);
+const correctFirstStep = forwardStep(model, firstTok, correctCache);
+// buggy: SKIP prefill — decode the same first token into a fresh, empty cache. The
+// model attends over an empty history (just this one token at pos 0) instead of the
+// 48-token prompt. Same model, same token, same code path — only the cache state differs.
+const buggyCache = newCache(DEFAULT_CONFIG);
+const buggyFirstStep = forwardStep(model, firstTok, buggyCache);
+const failDrift = maxLogitDrift(Array.from(correctFirstStep), Array.from(buggyFirstStep));
+const correctArg = argmax(correctFirstStep);
+const buggyArg = argmax(buggyFirstStep);
+console.log(`    correct cache.len after prefill = ${promptIds.length} (saw the whole prompt)`);
+console.log(`    buggy   cache.len               = 0 before decode (saw nothing)`);
+console.log(`    maxLogitDrift correct-vs-buggy = ${failDrift.toExponential(2)} (finite & large = silent wrong answer, not a crash)`);
+console.log(`    argmax next token: correct=${correctArg} buggy=${buggyArg} flipped=${correctArg !== buggyArg}`);
+console.log(`    => the cache IS the context. Skip prefill and the model answers a prompt it never read.\n`);
+
+console.log("=== stage02 done — cache is exact, speedup widens with length, memory is linear ===");

--- a/examples/llm-inference-from-scratch/src/stage03-sampling.ts
+++ b/examples/llm-inference-from-scratch/src/stage03-sampling.ts
@@ -1,0 +1,368 @@
+// stage03-sampling.ts — from a logit row to the next token: the sampler.
+//
+// The model gives you a vocab-wide logit vector per step. Picking the next token
+// from it is NOT a detail — it is the single biggest lever on output behavior the
+// engine exposes, and it sits on the decode hot path (it runs once per generated
+// token, forever). This stage implements the four knobs every real engine ships —
+// temperature, top-k, top-p (nucleus), repetition penalty — and MEASURES what each
+// one actually does to the distribution and to throughput, instead of reciting the
+// folklore ("higher temperature = more creative").
+//
+// What is real here vs what is toy:
+//   - The samplers are the real algorithms (same math vLLM / llama.cpp run).
+//   - Determinism is real: every sample uses mulberry32(seed), so "same seed =>
+//     same token sequence" is a bit-for-bit guarantee we PROVE below, not assert.
+//   - The per-step overhead numbers (d) are real wall-clock from performance.now()
+//     over the actual core forwardStep decode loop. Absolute tok/s is pessimistic
+//     (toy float64 kernels); the RELATIVE story — sampling is cheap next to the
+//     forward pass — is what transfers to a real engine.
+//   - The logit ROWS used for the distribution experiments (a,b,c,e) are fixed
+//     synthetic vectors chosen to expose the sharp-vs-flat behavior split, NOT model
+//     output. They are labeled as such. Using a crafted distribution is the honest
+//     way to show "top-k and top-p diverge when the distribution is flat" — a real
+//     model row would only sometimes be flat, hiding the effect behind luck (N=1).
+//
+// We do NOT import any stageNN file (they auto-run). We reuse core for everything
+// that already exists (softmax, mulberry32, the model + forwardStep, metrics).
+
+import { softmax, tensor } from "./core/tensor.js";
+import {
+  DEFAULT_CONFIG,
+  buildModel,
+  newCache,
+  forwardStep,
+  mulberry32,
+} from "./core/model.js";
+import { encode, PROMPTS } from "./core/tokenizer.js";
+import {
+  timeIt,
+  tokensPerSecond,
+  interTokenLatency,
+  argmax,
+} from "./core/metrics.js";
+
+// ---------------------------------------------------------------------------
+// Sampler primitives. Each takes a *copy-safe* logit row and returns a token id.
+// They are pure functions of (logits, params, rng) — no global state — which is
+// exactly what makes the determinism proof below possible.
+// ---------------------------------------------------------------------------
+
+// Convert logits to a probability distribution at a given temperature.
+//
+// Temperature T divides the logits before softmax. The invariant worth burning in:
+// softmax(z / T). T<1 sharpens (the top logit's lead grows), T>1 flattens (toward
+// uniform), T->0 is the limit of "all mass on the argmax" = greedy. We handle T==0
+// as a SPECIAL CASE (not 1/0): dividing by zero gives Infinity and softmax returns
+// NaN, so greedy is implemented as a one-hot on argmax. This is the first failure
+// mode the naive "just divide" code hits.
+function softmaxWithTemperature(logits: Float64Array, temperature: number): Float64Array {
+  if (temperature <= 0) {
+    // Greedy limit: one-hot on the argmax. Doing this explicitly (instead of
+    // softmax(z/0) -> NaN) is why T=0 "just works" as deterministic greedy.
+    const out = new Float64Array(logits.length);
+    out[argmax(logits)] = 1;
+    return out;
+  }
+  const scaled = new Float64Array(logits.length);
+  for (let i = 0; i < logits.length; i++) scaled[i] = logits[i] / temperature;
+  return softmax(tensor(scaled, [1, scaled.length])).data;
+}
+
+// Shannon entropy (in bits) of a probability distribution. This is our scalar
+// proxy for "diversity": maximal (log2 V) for uniform, 0 for a one-hot. We report
+// it because "temperature up => more diverse" is only credible if measured, and
+// entropy is the standard measure of how spread the next-token mass is.
+function entropyBits(probs: Float64Array): number {
+  let h = 0;
+  for (let i = 0; i < probs.length; i++) {
+    const p = probs[i];
+    if (p > 0) h -= p * Math.log2(p); // 0*log0 := 0, skip to avoid NaN
+  }
+  return h;
+}
+
+// Sample an index from a distribution using one draw of the seeded rng. Inverse-CDF
+// (walk the cumulative sum until it exceeds u). The final-index fallback guards the
+// case where floating-point rounding makes the cumulative sum end at 0.9999999 < u.
+function sampleFromDist(probs: Float64Array, rng: () => number): number {
+  const u = rng();
+  let cum = 0;
+  for (let i = 0; i < probs.length; i++) {
+    cum += probs[i];
+    if (u < cum) return i;
+  }
+  return probs.length - 1; // fp-rounding fallback; mass should already sum to ~1
+}
+
+// Build the top-k candidate set: keep the k highest-logit tokens, renormalize over
+// just those, zero the rest. Returns both the truncated distribution and how many
+// tokens survived (== k here, but we return it to compare against top-p, where the
+// count is data-dependent — that comparison is the point of experiment (c)).
+function topKDist(probs: Float64Array, k: number): { dist: Float64Array; kept: number } {
+  // index sort by probability desc; stable enough for our deterministic tie-break
+  // since argmax/first-max ordering is not needed here (we keep a *set*).
+  const idx = Array.from(probs.keys()).sort((a, b) => probs[b] - probs[a]);
+  const keep = Math.min(k, probs.length);
+  const out = new Float64Array(probs.length);
+  let sum = 0;
+  for (let i = 0; i < keep; i++) sum += probs[idx[i]];
+  // Renormalize over the kept set so the truncated vector is a valid distribution.
+  // If sum is 0 (degenerate all-zero input) we leave out as zeros; sampleFromDist's
+  // fallback then returns the last index — a loud-ish "your distribution is broken".
+  for (let i = 0; i < keep; i++) out[idx[i]] = sum > 0 ? probs[idx[i]] / sum : 0;
+  return { dist: out, kept: keep };
+}
+
+// Build the top-p (nucleus) candidate set: keep the smallest set of highest-prob
+// tokens whose cumulative mass >= p, renormalize over them. The candidate COUNT is
+// data-dependent — that is the entire difference from top-k. On a sharp distribution
+// a few tokens already cover p (small set); on a flat one it takes many (large set).
+function topPDist(probs: Float64Array, p: number): { dist: Float64Array; kept: number } {
+  const idx = Array.from(probs.keys()).sort((a, b) => probs[b] - probs[a]);
+  const out = new Float64Array(probs.length);
+  let cum = 0;
+  let kept = 0;
+  for (let i = 0; i < idx.length; i++) {
+    out[idx[i]] = probs[idx[i]];
+    cum += probs[idx[i]];
+    kept++;
+    // Stop once we've covered p. The >= means the token that crosses the threshold
+    // is included — nucleus sampling keeps the boundary token, it does not drop it.
+    if (cum >= p) break;
+  }
+  let sum = 0;
+  for (let i = 0; i < out.length; i++) sum += out[i];
+  for (let i = 0; i < out.length; i++) out[i] = sum > 0 ? out[i] / sum : 0;
+  return { dist: out, kept };
+}
+
+// Apply a repetition penalty to raw LOGITS (before temperature), the way the
+// original CTRL / HuggingFace formulation does: a token that already appeared has
+// its logit divided by penalty if positive, multiplied if negative. penalty>1
+// discourages repeats. The failure mode in (e): too large a penalty crushes even
+// the legitimately-correct next token, so we apply it to logits and let the caller
+// observe the argmax flip.
+function applyRepetitionPenalty(
+  logits: Float64Array,
+  seen: Set<number>,
+  penalty: number
+): Float64Array {
+  const out = Float64Array.from(logits);
+  for (const id of seen) {
+    if (id < 0 || id >= out.length) continue;
+    // The asymmetric positive/negative branch is the standard formulation: dividing
+    // a positive logit lowers it, but dividing a NEGATIVE logit would *raise* it
+    // (toward 0), which is backwards — so negatives are multiplied instead.
+    out[id] = out[id] > 0 ? out[id] / penalty : out[id] * penalty;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The fixed synthetic logit rows for the distribution experiments. NOT model
+// output — crafted to expose behavior. SHARP: one clear winner. FLAT: near-uniform
+// with a faint gradient. Vocab kept tiny (10) so the printed candidate counts are
+// readable; the algorithms are vocab-size-agnostic.
+// ---------------------------------------------------------------------------
+const SHARP_LOGITS = new Float64Array([8.0, 2.0, 1.5, 1.0, 0.5, 0.2, 0.1, 0.0, -0.5, -1.0]);
+const FLAT_LOGITS = new Float64Array([1.2, 1.1, 1.05, 1.0, 0.95, 0.9, 0.85, 0.8, 0.75, 0.7]);
+
+function fmt(n: number, d = 3): string {
+  return n.toFixed(d);
+}
+
+function main(): void {
+  console.log("=== stage03: 采样策略 — 从 logits 到下一个 token ===\n");
+  console.log("注：(a)(b)(c)(e) 用固定合成 logit 行（非模型输出，便于暴露行为分叉）；");
+  console.log("    (d) 用真实 core 模型 + forwardStep 解码热路径实测 wall-clock。\n");
+
+  // ---- (a) determinism: same seed => same token, across strategies & repeats ----
+  console.log("--- (a) 可复现性：同 seed 下每种策略重复运行结果一致 ---");
+  const SEED = 42;
+  const REPEATS = 5;
+  // Use a non-degenerate distribution: a peaked row (SHARP at T=1) puts ~0.99 mass
+  // on tok0, so EVERY seed lands on tok0 and the cross-seed control below could not
+  // actually demonstrate variation (it would look like greedy). FLAT at T=1.2 is
+  // spread enough that different seeds genuinely pick different tokens — which is
+  // what makes "same seed identical, different seed differs" a real two-sided proof.
+  const baseProbs = softmaxWithTemperature(FLAT_LOGITS, 1.2);
+  const strategies: { name: string; draw: (rng: () => number) => number }[] = [
+    { name: "temperature(T=1.0)", draw: (rng) => sampleFromDist(baseProbs, rng) },
+    { name: "top-k(k=3)", draw: (rng) => sampleFromDist(topKDist(baseProbs, 3).dist, rng) },
+    { name: "top-p(p=0.9)", draw: (rng) => sampleFromDist(topPDist(baseProbs, 0.9).dist, rng) },
+    { name: "greedy(T=0)", draw: () => argmax(FLAT_LOGITS) },
+  ];
+  for (const s of strategies) {
+    const runs: number[] = [];
+    for (let r = 0; r < REPEATS; r++) {
+      // Fresh PRNG per run from the SAME seed: this is what "reproducible" means —
+      // re-seeding resets the stream, so run r always sees the same u draws.
+      runs.push(s.draw(mulberry32(SEED)));
+    }
+    const allSame = runs.every((t) => t === runs[0]);
+    console.log(
+      `  ${s.name.padEnd(20)} ${REPEATS} 次 -> [${runs.join(", ")}]  identical=${allSame}`
+    );
+  }
+  // Cross-check: a DIFFERENT seed should be able to pick a different token (else the
+  // sampler is just disguised greedy). We show the token varies across seeds.
+  const seedTokens = [1, 2, 3, 4, 5, 6].map((sd) => sampleFromDist(baseProbs, mulberry32(sd)));
+  console.log(
+    `  控制对照 top-1 sampler 跨 6 个不同 seed -> [${seedTokens.join(", ")}] (应出现不同 token，证明不是伪随机退化为 greedy)\n`
+  );
+
+  // ---- (b) temperature -> entropy monotonicity ----
+  console.log("--- (b) 温度 T ↑ ⇒ 分布熵 ↑（多样性单调上升），熵单位 bit ---");
+  console.log(`    （SHARP 合成行，vocab=${SHARP_LOGITS.length}，均匀分布上界 = log2(${SHARP_LOGITS.length}) = ${fmt(Math.log2(SHARP_LOGITS.length))} bit）`);
+  const temps = [0.0, 0.5, 1.0, 1.5];
+  let prevEntropy = -1;
+  let monotonic = true;
+  for (const t of temps) {
+    const probs = softmaxWithTemperature(SHARP_LOGITS, t);
+    const h = entropyBits(probs);
+    const top = argmax(probs);
+    const topP = probs[top];
+    if (t > 0 && h < prevEntropy - 1e-12) monotonic = false; // T=0 is the one-hot floor
+    console.log(
+      `  T=${fmt(t, 1)}  entropy=${fmt(h)} bit   argmax=tok${top} p(argmax)=${fmt(topP)}`
+    );
+    prevEntropy = h;
+  }
+  console.log(`  熵随 T 单调非降 = ${monotonic}（T=0 为 one-hot 下界 0 bit）\n`);
+
+  // ---- (c) top-k vs top-p candidate-count divergence on sharp vs flat ----
+  console.log("--- (c) 同一 logits 下 top-k vs top-p 实际候选集大小对比 ---");
+  console.log("    top-k 候选数恒定；top-p 候选数随分布尖/平变化 —— 这是两者行为分叉点");
+  for (const [label, logits] of [
+    ["SHARP", SHARP_LOGITS],
+    ["FLAT", FLAT_LOGITS],
+  ] as const) {
+    const probs = softmaxWithTemperature(logits, 1.0);
+    const h = entropyBits(probs);
+    const k = 5;
+    const p = 0.9;
+    const kCount = topKDist(probs, k).kept;
+    const pCount = topPDist(probs, p).kept;
+    console.log(
+      `  ${label.padEnd(5)} (entropy=${fmt(h)} bit)  top-k(k=${k}) 候选=${kCount}   top-p(p=${p}) 候选=${pCount}`
+    );
+  }
+  console.log(
+    "  解读：SHARP 时 top-p 只需极少数 token 即覆盖 0.9（< k）；FLAT 时需要更多（≈ 或 > k）。\n"
+  );
+
+  // ---- (d) per-step sampling overhead on the REAL decode hot path ----
+  console.log("--- (d) 采样在 decode 热路径的 per-step 开销实测（真实 wall-clock）---");
+  const model = buildModel(DEFAULT_CONFIG, SEED);
+  const prompt = encode(PROMPTS[1]); // medium-length prompt (avoid N=1: see tokenizer)
+  const N_DECODE = 64;
+
+  // Helper: prefill then decode N tokens with a given next-token picker, returning
+  // per-step decode times. Prefill is excluded from the per-step series — we are
+  // isolating decode, where sampling actually lives.
+  function decodeWith(pick: (logits: Float64Array, seen: Set<number>, rng: () => number) => number): number[] {
+    const cache = newCache(DEFAULT_CONFIG);
+    let logits!: Float64Array;
+    for (const id of prompt) logits = forwardStep(model, id, cache); // prefill
+    const seen = new Set<number>(prompt);
+    const rng = mulberry32(SEED);
+    const perStep: number[] = [];
+    let next = pick(logits, seen, rng);
+    for (let i = 0; i < N_DECODE && cache.len < DEFAULT_CONFIG.maxSeq; i++) {
+      const ms = timeIt(() => {
+        logits = forwardStep(model, next, cache); // forward pass (the heavy part)
+      });
+      // Time the sampling decision SEPARATELY so we can attribute cost. We measure it
+      // outside the forward timer; the printed split is forward-ms vs sample-ms.
+      perStep.push(ms);
+      seen.add(next);
+      next = pick(logits, seen, rng);
+    }
+    return perStep;
+  }
+
+  // Measure the sampling decision alone, amortized, on a real logit row.
+  function timeSamplerOnly(pick: (logits: Float64Array, seen: Set<number>, rng: () => number) => number): number {
+    const cache = newCache(DEFAULT_CONFIG);
+    let logits!: Float64Array;
+    for (const id of prompt) logits = forwardStep(model, id, cache);
+    const seen = new Set<number>(prompt);
+    const rng = mulberry32(SEED);
+    const ITERS = 2000;
+    timeIt(() => { for (let i = 0; i < 50; i++) pick(logits, seen, rng); }); // warmup
+    const ms = timeIt(() => { for (let i = 0; i < ITERS; i++) pick(logits, seen, rng); });
+    return ms / ITERS;
+  }
+
+  const pickers: { name: string; pick: (l: Float64Array, s: Set<number>, r: () => number) => number }[] = [
+    { name: "greedy", pick: (l) => argmax(l) },
+    { name: "temperature(T=1.0)", pick: (l, _s, r) => sampleFromDist(softmaxWithTemperature(l, 1.0), r) },
+    { name: "top-k(k=40)", pick: (l, _s, r) => sampleFromDist(topKDist(softmaxWithTemperature(l, 1.0), 40).dist, r) },
+    { name: "top-p(p=0.9)", pick: (l, _s, r) => sampleFromDist(topPDist(softmaxWithTemperature(l, 1.0), 0.9).dist, r) },
+  ];
+
+  // Warmup the whole decode path once (JIT) before measuring, per metrics convention.
+  decodeWith((l) => argmax(l));
+
+  for (const { name, pick } of pickers) {
+    const perStep = decodeWith(pick);
+    const itl = interTokenLatency(perStep);
+    const totalMs = perStep.reduce((a, b) => a + b, 0);
+    const tps = tokensPerSecond(perStep.length, totalMs);
+    const samplerMs = timeSamplerOnly(pick);
+    const samplerPct = (samplerMs / (itl.mean + samplerMs)) * 100;
+    console.log(
+      `  ${name.padEnd(20)} forward ITL mean=${fmt(itl.mean)}ms p95=${fmt(itl.p95)}ms  ` +
+        `${fmt(tps, 1)} tok/s | sampler alone=${fmt(samplerMs, 4)}ms/tok (~${fmt(samplerPct, 2)}% of step)`
+    );
+  }
+  console.log(
+    "  解读：采样开销 << 前向传播。toy 绝对值偏乐观；可迁移的是“采样在热路径里占比极小”这一相对结论。\n"
+  );
+
+  // ---- (e) two failure modes ----
+  console.log("--- (e) 失败模式 ---");
+
+  // (e1) top-p=1.0 + high temperature collapses to near-uniform sampling.
+  console.log("  [e1] top-p=1.0 + 温度过高 ⇒ 近均匀采样（模型偏好被抹平）");
+  const uniformBound = Math.log2(SHARP_LOGITS.length);
+  for (const t of [1.0, 5.0, 50.0]) {
+    const probs = topPDist(softmaxWithTemperature(SHARP_LOGITS, t), 1.0).dist;
+    const h = entropyBits(probs);
+    const pct = (h / uniformBound) * 100;
+    console.log(
+      `       T=${fmt(t, 1)} top-p=1.0  entropy=${fmt(h)} bit (= ${fmt(pct, 1)}% of uniform ${fmt(uniformBound)})`
+    );
+  }
+  // Show the actual draws degrade to "could be anything": at T=50 the sampled token
+  // across seeds spreads across the vocab instead of favoring the strong tok0.
+  const hotDraws = [1, 2, 3, 4, 5, 6, 7, 8].map((sd) =>
+    sampleFromDist(topPDist(softmaxWithTemperature(SHARP_LOGITS, 50.0), 1.0).dist, mulberry32(sd))
+  );
+  console.log(
+    `       T=50 跨 8 seed 采样 -> [${hotDraws.join(", ")}]  (强势 tok0 不再主导，退化为掷骰子)\n`
+  );
+
+  // (e2) repetition penalty too large suppresses even the correct token.
+  console.log("  [e2] repetition penalty 过大 ⇒ 把正确 token 也压没");
+  // Craft a row where tok0 is the clearly-correct next token AND has already been
+  // seen (e.g. a legitimately repeated word). A sane penalty keeps it; a huge one
+  // flips the argmax to a wrong token. We print the flip.
+  const repLogits = new Float64Array([6.0, 5.0, 1.0, 0.5, 0.0]); // tok0 correct, tok1 close runner-up
+  const seenRep = new Set<number>([0]); // tok0 already appeared
+  for (const penalty of [1.0, 1.2, 10.0]) {
+    const penalized = applyRepetitionPenalty(repLogits, seenRep, penalty);
+    const before = argmax(repLogits);
+    const after = argmax(penalized);
+    const flipped = before !== after;
+    console.log(
+      `       penalty=${fmt(penalty, 1)}  logit[tok0] ${fmt(repLogits[0], 2)} -> ${fmt(penalized[0], 2)}  ` +
+        `argmax ${before} -> ${after}  ${flipped ? "⚠ 正确 token 被压没" : "OK"}`
+    );
+  }
+  console.log(
+    "       解读：penalty 是钝器。轻度抑制重复无害；过大时把 logit 压到次优 token 之下，正确答案被牺牲。"
+  );
+}
+
+main();

--- a/examples/llm-inference-from-scratch/src/stage04-continuous-batch.ts
+++ b/examples/llm-inference-from-scratch/src/stage04-continuous-batch.ts
@@ -1,0 +1,437 @@
+// stage04-continuous-batch.ts — 连续批处理：让推理引擎不空转，把吞吐榨干。
+//
+// 问题: 一批请求的生成长度方差极大（一个回 "yes"，一个写一篇长文）。怎么调度
+// 它们共享同一份模型权重，决定了 GPU 是满载还是大半时间在等最慢那个请求。
+//
+// 两种策略，本 stage 用 REAL forwardStep 实测对照:
+//
+//   STATIC batching（朴素）: 一批请求一起开跑，整批必须等到 *最长* 的那个生成完才
+//     释放。短请求早早算完，但它的 slot 在原地空转直到全批结束 —— 这就是 head-of-
+//     line blocking（队头阻塞）: 一个长请求把同批所有短请求的完成延迟一起拖到它的
+//     长度。利用率 = 每步实际还在算的 slot 数 / batch 容量，随长请求拖尾断崖式下跌。
+//
+//   CONTINUOUS batching（vLLM/Orca 的做法）: 调度单位是 *一个 decode step*，不是
+//     "一整批"。每步结束: 算完的序列立刻离场释放 slot，等待队列里的新请求立刻补位。
+//     于是每一步 batch 都尽量填满，短请求一算完就走、不被长请求绑架。
+//
+// 不变量（本 stage 的 load-bearing 断言）: 两种策略对 *同一个请求* 产出 bit-for-bit
+//   相同的 token 序列。调度只改"谁和谁同一步算"，绝不改单个序列的数学。我们用
+//   maxLogitDrift==0 / token 序列逐位相等来证明，否则任何吞吐数字都是耍流氓。
+//
+// 诚实数字: 模型是 toy（synthetic 权重、float64 标量 kernel），所以绝对 tok/s 偏
+//   悲观。可迁移的是 *相对* 量: 连续批 vs 静态批的吞吐加速比、利用率差、短请求 p99
+//   的改善 —— 这些比值在真实引擎上同样成立。所有时间都是 performance.now wall-clock。
+//
+// 这里没有真 GPU，"利用率"指 *算子有效占用率*: 每个 decode step 我们真正执行了多少
+//   个 active slot 的 forwardStep，除以 batch 容量。真实引擎里这正比于 GPU 利用率
+//   （padding 出来的空 slot 在真硬件上要么浪费算力、要么靠 ragged kernel 省掉）。
+
+import { DEFAULT_CONFIG, buildModel, forwardStep, newCache, type KVCache, type Model } from "./core/model.js";
+import { encode, PROMPTS } from "./core/tokenizer.js";
+import {
+  timeIt,
+  tokensPerSecond,
+  estimateKVBytes,
+  formatBytes,
+  speedup,
+  maxLogitDrift,
+  argmax,
+} from "./core/metrics.js";
+
+const cfg = DEFAULT_CONFIG;
+const model: Model = buildModel(cfg, 42);
+
+// A single inference request. genLen is how many tokens it wants to decode — the
+// quantity whose VARIANCE is the whole point of this chapter. promptIds drives a
+// real prefill so timings and KV growth are honest, not synthetic counters.
+type Request = {
+  id: number;
+  promptIds: number[];
+  genLen: number; // target number of decode steps for this request
+};
+
+// Live decode state for one request occupying a batch slot. cache holds its KV
+// history; produced is the tokens generated so far; nextToken is the input for the
+// upcoming step (argmax-greedy so the run is deterministic).
+type Slot = {
+  req: Request;
+  cache: KVCache;
+  produced: number[];
+  nextToken: number;
+};
+
+// --- workload: high-variance generation lengths -------------------------------
+//
+// The classic bimodal traffic an inference server sees: a few long generations
+// mixed with many short ones. Static batching suffers exactly here; uniform lengths
+// would hide the problem (and be an N=1-style lie about real traffic).
+function makeWorkload(): Request[] {
+  const genLens = [4, 40, 8, 32, 6, 36, 5, 30]; // mean 20, but spread 4..40 (10x)
+  return genLens.map((genLen, i) => ({
+    id: i,
+    // alternate the short(3) and medium(48) prompts so prefill cost varies too. We
+    // avoid the 235-token prompt here: 235 + genLen(≤40) would exceed maxSeq(256),
+    // and KV growth is studied in stage05 — this chapter is about scheduling.
+    promptIds: encode(PROMPTS[i % 2]),
+    genLen,
+  }));
+}
+
+// Prefill a fresh slot: run the prompt through the cached path so its KV is warm,
+// and seed nextToken from the prompt's last-token logits. This is real work (one
+// forwardStep per prompt token), shared identically by both schedulers — so any
+// throughput difference comes from SCHEDULING, not from a kernel change.
+function admit(req: Request): Slot {
+  const cache = newCache(cfg);
+  // annotate as plain Float64Array (not the ArrayBuffer-narrowed `new` type) so the
+  // reassignment from forwardStep type-checks under @types/node 22 — same fix the
+  // core applies in forwardStep itself.
+  let last: Float64Array = new Float64Array(cfg.vocabSize);
+  for (const id of req.promptIds) last = forwardStep(model, id, cache);
+  return { req, cache, produced: [], nextToken: argmax(last) };
+}
+
+// Execute ONE useful decode step for ONE slot: run the model, append the token.
+// Mutates the slot's cache (KV grows one row). This is the atomic unit of useful
+// work; both schedulers are built from it.
+function decodeOneStep(slot: Slot): void {
+  const logits = forwardStep(model, slot.nextToken, slot.cache);
+  slot.nextToken = argmax(logits);
+  slot.produced.push(slot.nextToken);
+}
+
+// padStep — the WASTE of a static batch, modeled honestly.
+//
+// Why this exists: a GPU runs one batched matmul over the FULL batch width. A slot
+// whose request already finished is not free — unless you use ragged/variable-length
+// kernels (exactly the complexity continuous batching buys), the dead slot is PADDED
+// and its rows still flow through every matmul. So a static step costs `capacity`
+// forward passes regardless of how many slots are still alive. We reproduce that
+// real cost by burning one genuine forward pass on a throwaway scratch slot. Without
+// this, our scalar toy would skip dead slots and falsely show static == continuous
+// in wall-clock; padStep is what makes the wall-clock speedup honest rather than a
+// step-count artifact.
+const scratchCache: KVCache = (() => {
+  const c = newCache(cfg);
+  forwardStep(model, 0, c); // 1 cached row so subsequent steps are O(1)-ish, like a live slot
+  return c;
+})();
+function padStep(): void {
+  // reset scratch when it nears maxSeq so the padded compute stays representative of
+  // a mid-decode step and never throws on the position bound.
+  if (scratchCache.len >= cfg.maxSeq - 1) {
+    const fresh = newCache(cfg);
+    forwardStep(model, 0, fresh);
+    scratchCache.k = fresh.k;
+    scratchCache.v = fresh.v;
+    scratchCache.len = fresh.len;
+  }
+  forwardStep(model, 0, scratchCache); // real compute, discarded — the padding cost
+}
+
+type RunResult = {
+  label: string;
+  wallMs: number;
+  totalTokens: number; // useful tokens produced (excludes padded waste)
+  totalSteps: number; // number of global scheduler steps taken
+  busySlotSteps: number; // sum over steps of active-slot count (utilization numerator)
+  capacitySteps: number; // sum over steps of capacity (utilization denominator)
+  trajectory: string[]; // per-step textual snapshot of slot occupancy
+  completionStep: Map<number, number>; // reqId -> global step at which it finished (arrival t=0)
+  tokensByReq: Map<number, number[]>; // reqId -> produced tokens (for equivalence check)
+};
+
+// --- STATIC batching ----------------------------------------------------------
+//
+// Fill the batch once, run until EVERY slot's request is done, then (and only then)
+// admit the next batch. A slot whose request finished early goes idle but is NOT
+// refilled until the whole batch drains — and it still pays a padded forward pass
+// every step (padStep). That padded waste is the defining cost of static batching.
+//
+// Latency is recorded as the GLOBAL step at finish. All requests arrive at t=0, so
+// a request stuck behind an earlier batch carries that whole queue wait in its
+// completion step — this is the head-of-line blocking the chapter is about.
+function runStatic(requests: Request[], capacity: number): RunResult {
+  const trajectory: string[] = [];
+  const completionStep = new Map<number, number>();
+  const tokensByReq = new Map<number, number[]>();
+  let totalTokens = 0;
+  let busySlotSteps = 0;
+  let capacitySteps = 0;
+  let globalStep = 0;
+  const queue = [...requests];
+
+  const wallMs = timeIt(() => {
+    while (queue.length > 0) {
+      // form one static batch
+      const batch: (Slot | null)[] = [];
+      while (batch.length < capacity && queue.length > 0) {
+        batch.push(admit(queue.shift()!));
+      }
+      // run until ALL slots in this batch are finished
+      let anyActive = true;
+      while (anyActive) {
+        anyActive = false;
+        let activeThisStep = 0;
+        const marks: string[] = [];
+        for (let s = 0; s < capacity; s++) {
+          const slot = batch[s] ?? null;
+          if (slot && slot.produced.length < slot.req.genLen) {
+            decodeOneStep(slot);
+            totalTokens++;
+            activeThisStep++;
+            anyActive = true;
+            marks.push(`R${slot.req.id}`);
+            if (slot.produced.length === slot.req.genLen) {
+              completionStep.set(slot.req.id, globalStep + 1); // 1-based: arrival t=0
+              tokensByReq.set(slot.req.id, slot.produced);
+            }
+          } else if (slot) {
+            // finished-but-not-evicted slot: pays a PADDED forward pass (real GPU
+            // cost) while producing nothing. This is the waste continuous removes.
+            padStep();
+            marks.push("··");
+          } else {
+            marks.push("--");
+          }
+        }
+        if (anyActive) {
+          busySlotSteps += activeThisStep;
+          capacitySteps += capacity;
+          if (trajectory.length < 24) {
+            trajectory.push(`step ${String(globalStep).padStart(3)} [${marks.join(" ")}] active=${activeThisStep}/${capacity}`);
+          }
+          globalStep++;
+        }
+      }
+    }
+  });
+
+  return {
+    label: `static (cap=${capacity})`,
+    wallMs,
+    totalTokens,
+    totalSteps: globalStep,
+    busySlotSteps,
+    capacitySteps,
+    trajectory,
+    completionStep,
+    tokensByReq,
+  };
+}
+
+// --- CONTINUOUS batching ------------------------------------------------------
+//
+// The scheduler's unit is a step, not a batch. Each step: run every active slot
+// once; then evict finished slots and immediately backfill empty slots from the
+// queue. The batch composition churns step-to-step — that churn is exactly what
+// keeps utilization near 100% and lets a short request leave the instant it's done.
+function runContinuous(requests: Request[], capacity: number): RunResult {
+  const trajectory: string[] = [];
+  const completionStep = new Map<number, number>();
+  const tokensByReq = new Map<number, number[]>();
+  let totalTokens = 0;
+  let busySlotSteps = 0;
+  let capacitySteps = 0;
+  let globalStep = 0;
+  const queue = [...requests];
+  const slots: (Slot | null)[] = new Array(capacity).fill(null);
+
+  const wallMs = timeIt(() => {
+    // seed: fill all slots up front
+    for (let s = 0; s < capacity && queue.length > 0; s++) {
+      slots[s] = admit(queue.shift()!);
+    }
+    while (slots.some((x) => x !== null)) {
+      let activeThisStep = 0;
+      const marks: string[] = [];
+      for (let s = 0; s < capacity; s++) {
+        const slot = slots[s];
+        if (slot) {
+          decodeOneStep(slot);
+          totalTokens++;
+          activeThisStep++;
+          marks.push(`R${slot.req.id}`);
+        } else {
+          // an empty slot is NOT padded here: continuous batching only ever leaves a
+          // slot empty when the queue is fully drained (nothing left to backfill), so
+          // there is no waste to model — that absence of padding IS the optimization.
+          marks.push("--");
+        }
+      }
+      busySlotSteps += activeThisStep;
+      capacitySteps += capacity;
+      if (trajectory.length < 24) {
+        trajectory.push(`step ${String(globalStep).padStart(3)} [${marks.join(" ")}] active=${activeThisStep}/${capacity}`);
+      }
+      // evict finished, backfill from queue — the continuous part.
+      for (let s = 0; s < capacity; s++) {
+        const slot = slots[s];
+        if (slot && slot.produced.length >= slot.req.genLen) {
+          completionStep.set(slot.req.id, globalStep + 1); // 1-based: arrival t=0
+          tokensByReq.set(slot.req.id, slot.produced);
+          // admit the next queued request into this freed slot THIS same step.
+          slots[s] = queue.length > 0 ? admit(queue.shift()!) : null;
+        }
+      }
+      globalStep++;
+    }
+  });
+
+  return {
+    label: `continuous (cap=${capacity})`,
+    wallMs,
+    totalTokens,
+    totalSteps: globalStep,
+    busySlotSteps,
+    capacitySteps,
+    trajectory,
+    completionStep,
+    tokensByReq,
+  };
+}
+
+// percentile over an array of latencies (steps), nearest-rank, sorted ascending.
+function pct(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
+}
+
+function utilization(r: RunResult): number {
+  return r.capacitySteps === 0 ? 0 : r.busySlotSteps / r.capacitySteps;
+}
+
+// ============================================================================
+console.log("=== stage04 连续批处理 (continuous batching) ===\n");
+
+const CAPACITY = 4;
+const workload = makeWorkload();
+console.log(`workload: ${workload.length} 个请求, 生成长度 = [${workload.map((r) => r.genLen).join(", ")}]`);
+console.log(`          (mean=${(workload.reduce((a, r) => a + r.genLen, 0) / workload.length).toFixed(1)}, min=${Math.min(...workload.map((r) => r.genLen))}, max=${Math.max(...workload.map((r) => r.genLen))} — 10x 方差)`);
+console.log(`batch 容量 = ${CAPACITY} slots\n`);
+
+// warmup (metrics.timeIt convention: first run pays JIT/cold-cache cost)
+runStatic(makeWorkload(), CAPACITY);
+runContinuous(makeWorkload(), CAPACITY);
+
+const stat = runStatic(makeWorkload(), CAPACITY);
+const cont = runContinuous(makeWorkload(), CAPACITY);
+
+// --- (0) equivalence: scheduling must not change any request's output ---------
+console.log("[0] 不变量 — 调度不改单序列数学 (per-request token equivalence):");
+let maxDrift = 0;
+let allMatch = true;
+for (const req of workload) {
+  const a = stat.tokensByReq.get(req.id)!;
+  const b = cont.tokensByReq.get(req.id)!;
+  const same = a.length === b.length && a.every((t, i) => t === b[i]);
+  if (!same) allMatch = false;
+  maxDrift = Math.max(maxDrift, maxLogitDrift(a, b));
+}
+console.log(`    所有 ${workload.length} 个请求: static 与 continuous 产出 token 序列逐位相等 = ${allMatch}`);
+console.log(`    token-id maxDrift = ${maxDrift.toExponential(2)} (0 => 调度纯粹是编排, 数学不变)\n`);
+
+// --- (a) throughput + utilization ---------------------------------------------
+console.log("[a] 整体吞吐 + 算子有效利用率 (real wall-clock):");
+const statTps = tokensPerSecond(stat.totalTokens, stat.wallMs);
+const contTps = tokensPerSecond(cont.totalTokens, cont.wallMs);
+console.log(`    static     : ${stat.totalTokens} tok in ${stat.wallMs.toFixed(1)} ms over ${stat.totalSteps} steps`);
+console.log(`                 throughput = ${statTps.toFixed(1)} tok/s   利用率 = ${(utilization(stat) * 100).toFixed(1)}% (busy ${stat.busySlotSteps}/${stat.capacitySteps} slot-steps)`);
+console.log(`    continuous : ${cont.totalTokens} tok in ${cont.wallMs.toFixed(1)} ms over ${cont.totalSteps} steps`);
+console.log(`                 throughput = ${contTps.toFixed(1)} tok/s   利用率 = ${(utilization(cont) * 100).toFixed(1)}% (busy ${cont.busySlotSteps}/${cont.capacitySteps} slot-steps)`);
+console.log(`    speedup (continuous / static) = ${speedup(stat.wallMs, cont.wallMs).toFixed(2)}x wall-clock, ${(contTps / statTps).toFixed(2)}x tok/s`);
+console.log(`    (绝对 tok/s 偏悲观 — toy 模型 + 标量 kernel; 可迁移的是利用率差与加速比)\n`);
+
+// --- (b) per-request completion latency, p50/p99 ------------------------------
+//
+// Measured in SCHEDULER STEPS from ARRIVAL (all requests arrive at t=0), not wall-
+// clock, because the head-of-line story is about *position in the schedule*, not
+// kernel speed. The completion step includes any queue wait: a request in a later
+// static batch eats the full drain time of every batch ahead of it. Under continuous
+// it is admitted the instant a slot frees, so it waits far less.
+console.log("[b] 每请求完成延迟 (steps from arrival t=0 to done) + 队头阻塞:");
+const statLat = workload.map((r) => stat.completionStep.get(r.id)!);
+const contLat = workload.map((r) => cont.completionStep.get(r.id)!);
+console.log(`    request ids       : [${workload.map((r) => ("R" + r.id).padStart(3)).join(", ")}]`);
+console.log(`    request genLens   : [${workload.map((r) => String(r.genLen).padStart(3)).join(", ")}]`);
+console.log(`    static latency    : [${statLat.map((x) => String(x).padStart(3)).join(", ")}]  <- 第二批请求(R4..R7)含整批排队等待`);
+console.log(`    continuous latency: [${contLat.map((x) => String(x).padStart(3)).join(", ")}]  <- 一有空 slot 立即补位, 等待少`);
+console.log(`    static     p50=${pct(statLat, 50)} p99=${pct(statLat, 99)} max=${Math.max(...statLat)} steps`);
+console.log(`    continuous p50=${pct(contLat, 50)} p99=${pct(contLat, 99)} max=${Math.max(...contLat)} steps`);
+// R4 (genLen=6) lands in the 2nd static batch -> waits for batch-1's longest (R1, 40).
+console.log(`    短请求 R4 (genLen=6): static 完成于第 ${stat.completionStep.get(4)} step vs continuous 第 ${cont.completionStep.get(4)} step`);
+console.log(`    => 静态批的队头阻塞: 一个 6-token 请求因排在长批之后, p99 被拖到批内最长请求量级\n`);
+
+// --- (c) continuous-batch composition trajectory ------------------------------
+//
+// Read the columns: each step a slot shows its request id (R<n>) or -- (empty).
+// Watch slots churn — a short request leaves and a queued one takes its place mid-
+// flight, which a static batch can never do.
+console.log("[c] 连续批 — batch 组成随 step 变化轨迹 (R<n>=该 slot 在算请求 n, --=空):");
+for (const line of cont.trajectory) console.log(`    ${line}`);
+console.log(`    (slot 列在 step 间换人 = backfill 生效; 静态批同一批的列固定不变)\n`);
+
+// Contrast: static trajectory shows the idle '··' waste once short reqs finish.
+console.log("    对照 static 轨迹 (··=slot 已算完但被占住空转, 队头阻塞的浪费):");
+for (const line of stat.trajectory) console.log(`    ${line}`);
+console.log("");
+
+// --- (d) FAILURE MODES --------------------------------------------------------
+console.log("[d] 失败模式 — 调度器必须算两笔账: 单步延迟 与 显存:\n");
+
+// (d.1) capacity set too large => single-step latency spike.
+//
+// Throughput tempts you to crank capacity. But one decode step now runs `capacity`
+// forwardSteps back-to-back before ANY token is returned, so per-step latency (the
+// thing every concurrent user feels as a stall) grows ~linearly with capacity. A
+// real engine bounds capacity precisely to cap this tail latency.
+console.log("(d.1) batch 容量设太大 => 单步延迟尖峰 (吞吐与延迟的对立):");
+for (const capTest of [1, 4, 16]) {
+  const reqs: Request[] = Array.from({ length: capTest }, (_, i) => ({
+    id: i,
+    promptIds: encode(PROMPTS[1]),
+    genLen: 8,
+  }));
+  const slots = reqs.map((r) => admit(r));
+  // warmup one step
+  for (const sl of slots) decodeOneStep(sl);
+  // measure ONE full scheduler step (all slots advance once) — the latency a user waits.
+  const stepMs = timeIt(() => {
+    for (const sl of slots) decodeOneStep(sl);
+  });
+  console.log(`    cap=${String(capTest).padStart(2)}: 单步全 batch = ${stepMs.toFixed(3)} ms  => 每 token 平均 ${(stepMs / capTest).toFixed(3)} ms, 但首字延迟随容量线性上升`);
+}
+console.log("    => 容量越大吞吐越高, 但单步(及尾延迟)随之上升; 调度器要在两者间设上限\n");
+
+// (d.2) KV cache memory overflow => scheduler must REJECT, not OOM.
+//
+// Each admitted sequence costs estimateKVBytes. A scheduler that admits blindly
+// will run the box out of memory mid-decode (the worst time to fail). A correct
+// scheduler does capacity-planning arithmetic on admission and rejects/queues when
+// the next sequence won't fit. We demonstrate the rejection, not a crash.
+console.log("(d.2) KV cache 显存被并发请求撑爆 => 调度器必须拒绝, 不能 OOM:");
+const KV_BUDGET_BYTES = 6 * 1024 * 1024; // 6 MiB toy budget for the KV pool
+const ADMIT_SEQ_LEN = 256; // assume each admitted seq reserves maxSeq worth of KV
+const perSeqBytes = estimateKVBytes(cfg, ADMIT_SEQ_LEN, 1);
+console.log(`    KV 池预算 = ${formatBytes(KV_BUDGET_BYTES)} (est.), 每序列保留 seq=${ADMIT_SEQ_LEN} => ${formatBytes(perSeqBytes)} (est.)`);
+let admittedBytes = 0;
+let admittedCount = 0;
+let rejected = 0;
+for (let i = 0; i < 64; i++) {
+  // admission control: only admit if the running KV total still fits the budget.
+  if (admittedBytes + perSeqBytes <= KV_BUDGET_BYTES) {
+    admittedBytes += perSeqBytes;
+    admittedCount++;
+  } else {
+    rejected++;
+    if (rejected === 1) {
+      console.log(`    在第 ${i + 1} 个请求处拒绝: ${formatBytes(admittedBytes)} + ${formatBytes(perSeqBytes)} > ${formatBytes(KV_BUDGET_BYTES)} (est.)`);
+    }
+  }
+}
+console.log(`    => 接纳 ${admittedCount} 个请求 (占 ${formatBytes(admittedBytes)} est.), 拒绝 ${rejected} 个`);
+console.log(`    理论上限 = floor(${formatBytes(KV_BUDGET_BYTES)} / ${formatBytes(perSeqBytes)}) = ${Math.floor(KV_BUDGET_BYTES / perSeqBytes)} 序列`);
+console.log(`    => 调度器算显存账后主动 backpressure (排队/拒绝), 而不是跑到一半 OOM 崩掉\n`);
+
+console.log("=== stage04 done — 调度只改编排, 不改单序列数学; 连续批用利用率换吞吐, 但容量与显存是硬上限 ===");

--- a/examples/llm-inference-from-scratch/src/stage05-paged-kv.ts
+++ b/examples/llm-inference-from-scratch/src/stage05-paged-kv.ts
@@ -1,0 +1,365 @@
+// stage05-paged-kv.ts — PagedAttention: manage the KV cache like an OS manages RAM.
+//
+// The problem this chapter solves (and the one chapter 02's contiguous cache
+// created): a contiguous KV cache must reserve maxSeq slots PER sequence up front,
+// because it grows by reallocating one flat array (see core/model.forwardStep). If
+// you serve N concurrent requests you reserve N * maxSeq, but most requests finish
+// far short of maxSeq — the reserved-but-unused tail is pure internal fragmentation.
+// vLLM's PagedAttention fixes this exactly the way an OS fixes external memory
+// fragmentation: chop the cache into fixed-size BLOCKS (pages), hand them out on
+// demand, and keep a per-sequence BLOCK TABLE (page table) mapping logical position
+// -> physical block. A sequence only ever holds ceil(len/blockSize) blocks, so the
+// only waste is the partly-filled last block — bounded by blockSize, not maxSeq.
+//
+// What this stage proves with REAL numbers:
+//   (a) memory: contiguous-reserved vs paged footprint + internal fragmentation %.
+//   (b) capacity: under a fixed VRAM budget, paged fits dramatically more sequences.
+//   (c) correctness: paged-attention last-token logits == contiguous, drift == 0.
+//       This is THE load-bearing invariant — paging is a memory layout change, it
+//       must not touch the math. We get it for free by gathering blocks into the
+//       exact contiguous layout core/_internal.blockStep already expects.
+//   (d) prefix sharing: many requests share one system-prompt prefix by pointing
+//       their block tables at the SAME physical blocks (copy-on-nothing) — saves
+//       both memory and the prefill compute for the shared span.
+//   (e) FAILURE MODE: a corrupted block table entry makes attention read another
+//       request's KV, silently poisoning the logits. Paging buys efficiency at the
+//       cost of a new, sharp consistency hazard the engine must never get wrong.
+//
+// Honesty caveats (inherited from core/metrics header):
+//   - memory numbers are exact float64 arithmetic, printed "(est.)" — they are the
+//     capacity-planning numbers a real engine uses, not a process RSS measurement.
+//   - timings are real performance.now() wall-clock (warmed up first), but the toy
+//     model is tiny and the kernels are naive float64 loops, so ABSOLUTE ms is
+//     pessimistic. What transfers is the RELATIVE story: the fragmentation %, the
+//     capacity multiplier, and the prefix-share speedup ratio.
+
+import { DEFAULT_CONFIG, buildModel, forwardNoCache, newCache, forwardStep, _internal, type Model, type ModelConfig } from "./core/model.js";
+import { encode, PROMPTS } from "./core/tokenizer.js";
+import { timeIt, estimateKVBytes, formatBytes, maxLogitDrift, argmax, speedup } from "./core/metrics.js";
+
+// blockStep is the per-token unit both core forward paths use; reusing it (instead
+// of re-deriving attention) is what guarantees the paged path's arithmetic is
+// bit-identical to the contiguous reference. logitsFromHidden projects the final
+// hidden to vocab logits — same function the reference uses.
+const { blockStep, logitsFromHidden } = _internal;
+
+// Block size: positions per page. Real engines use 16; we use 8 so the toy prompts
+// (lengths 3 / 48 / 235) straddle several blocks and the partial-last-block
+// fragmentation is visible rather than a rounding artifact. Smaller blocks = less
+// internal waste but more block-table overhead; this trade-off is the whole tuning
+// knob, so it lives as a named constant, not a literal.
+const BLOCK_SIZE = 8;
+
+// --- the paged KV pool --------------------------------------------------------
+//
+// A physical pool of blocks shared by all sequences. Each block stores, for ONE
+// layer, BLOCK_SIZE positions of K and V laid out flat row-major [BLOCK_SIZE, kvDim]
+// — the SAME layout core packs a contiguous cache in, so a gathered run of blocks is
+// byte-compatible with what blockStep expects. We key blocks by (layer, blockIdx)
+// because each layer has its own KV; a real engine interleaves layers in one block,
+// but per-layer keeps the toy code readable without changing the accounting.
+type PagedKVPool = {
+  cfg: ModelConfig;
+  kvDim: number; // nKVHeads * dHead, the row width
+  // per layer: a growable array of physical blocks (each a flat [BLOCK_SIZE*kvDim]).
+  // freeList holds reclaimed block indices for reuse (the OS free-page list).
+  blocksK: Float64Array[][]; // blocksK[layer][physBlock]
+  blocksV: Float64Array[][];
+  freeList: number[]; // physical block indices available for (re)allocation, per the analogy
+  nextFresh: number; // next never-before-allocated physical index
+  allocated: number; // high-water mark of blocks ever live, for the footprint number
+};
+
+function newPool(cfg: ModelConfig): PagedKVPool {
+  return {
+    cfg,
+    kvDim: cfg.nKVHeads * cfg.dHead,
+    blocksK: Array.from({ length: cfg.nLayers }, () => []),
+    blocksV: Array.from({ length: cfg.nLayers }, () => []),
+    freeList: [],
+    nextFresh: 0,
+    allocated: 0,
+  };
+}
+
+// allocBlock — hand out one physical block index, preferring the free list (page
+// reuse) over growing the pool. Returns the index valid across ALL layers: we keep
+// per-layer block arrays in lock-step so one block table works for every layer.
+function allocBlock(pool: PagedKVPool): number {
+  const idx = pool.freeList.length > 0 ? pool.freeList.pop()! : pool.nextFresh++;
+  for (let l = 0; l < pool.cfg.nLayers; l++) {
+    // grow the per-layer arrays to cover this index; fresh blocks are zeroed K/V.
+    if (pool.blocksK[l][idx] === undefined) {
+      pool.blocksK[l][idx] = new Float64Array(BLOCK_SIZE * pool.kvDim);
+      pool.blocksV[l][idx] = new Float64Array(BLOCK_SIZE * pool.kvDim);
+    }
+  }
+  pool.allocated = Math.max(pool.allocated, pool.nextFresh);
+  return idx;
+}
+
+// A sequence's view of the cache: a block table (logical block -> physical index)
+// plus how many positions are filled. refcount-sharing of prefix blocks is done by
+// simply listing the same physical index in two sequences' tables (demo (d)).
+type PagedSeq = {
+  blockTable: number[]; // logical block i lives at physical blockTable[i]
+  len: number; // positions currently cached
+};
+
+// pagedStep — one cached forward step for `seq`, reading/writing through the pool.
+//
+// This is the paged analogue of core/model.forwardStep. The ONLY difference from the
+// contiguous path is HOW K/V history is sourced and stored: we gather the sequence's
+// blocks into a contiguous scratch, run the IDENTICAL blockStep, then scatter the new
+// row back into the correct block slot. Same arithmetic => same logits (proven in (c)).
+//
+// Invariant: seq.len is the absolute position of the incoming token (mirrors the
+// contiguous cache's len==pos precondition). Caller advances len via this function.
+function pagedStep(model: Model, tokenId: number, seq: PagedSeq, pool: PagedKVPool): Float64Array {
+  const cfg = model.cfg;
+  const pos = seq.len;
+  if (pos >= cfg.maxSeq) throw new Error(`pagedStep: position ${pos} >= maxSeq ${cfg.maxSeq}`);
+  const kvDim = pool.kvDim;
+
+  // Ensure a block exists for the slot this token will occupy. The OS analogue:
+  // page fault on first write to a logical page -> allocate a physical frame.
+  const logicalBlock = Math.floor(pos / BLOCK_SIZE);
+  const slotInBlock = pos % BLOCK_SIZE;
+  if (seq.blockTable[logicalBlock] === undefined) {
+    seq.blockTable[logicalBlock] = allocBlock(pool);
+  }
+
+  // h is the running hidden vector. Annotated as plain Float64Array (not the
+  // ArrayBuffer-narrowed `new` type) so reassignment from blockStep type-checks
+  // under @types/node 22 — same fix the core path documents.
+  let h: Float64Array = new Float64Array(cfg.dModel);
+  h.set(model.embed.data.subarray(tokenId * cfg.dModel, (tokenId + 1) * cfg.dModel));
+
+  for (let l = 0; l < cfg.nLayers; l++) {
+    const w = model.layers[l];
+    // GATHER: copy the `pos` cached rows out of the (possibly non-contiguous) blocks
+    // into one flat [pos, kvDim] scratch, exactly the layout blockStep reads. This
+    // gather is the runtime cost paging pays for its memory win; a real engine fuses
+    // it into the attention kernel ("paged attention kernel") so it is ~free, but
+    // here we keep it explicit so the mechanism is visible.
+    const kHist = new Float64Array(pos * kvDim);
+    const vHist = new Float64Array(pos * kvDim);
+    for (let p = 0; p < pos; p++) {
+      const lb = Math.floor(p / BLOCK_SIZE);
+      const sib = p % BLOCK_SIZE;
+      const phys = seq.blockTable[lb];
+      kHist.set(pool.blocksK[l][phys].subarray(sib * kvDim, (sib + 1) * kvDim), p * kvDim);
+      vHist.set(pool.blocksV[l][phys].subarray(sib * kvDim, (sib + 1) * kvDim), p * kvDim);
+    }
+
+    const r = blockStep(h, w, pos, kHist, vHist, pos, cfg);
+
+    // SCATTER: write this token's freshly-computed K/V into its physical slot.
+    const phys = seq.blockTable[logicalBlock];
+    pool.blocksK[l][phys].set(r.k, slotInBlock * kvDim);
+    pool.blocksV[l][phys].set(r.v, slotInBlock * kvDim);
+    h = r.h;
+  }
+  seq.len = pos + 1;
+  return logitsFromHidden(h, model);
+}
+
+// run a whole prompt through the paged path and return last-token logits.
+function pagedPrefill(model: Model, tokenIds: number[], pool: PagedKVPool): { seq: PagedSeq; lastLogits: Float64Array } {
+  const seq: PagedSeq = { blockTable: [], len: 0 };
+  // annotate as plain Float64Array (not the ArrayBuffer-narrowed `new` type) so the
+  // reassignment from pagedStep's return type-checks under @types/node 22 — same fix
+  // the core forward paths document.
+  let last: Float64Array = new Float64Array(model.cfg.vocabSize);
+  for (const id of tokenIds) last = pagedStep(model, id, seq, pool);
+  return { seq, lastLogits: last };
+}
+
+// blocks a sequence of `len` positions needs under paging.
+function blocksNeeded(len: number): number {
+  return Math.ceil(len / BLOCK_SIZE);
+}
+
+console.log("=== stage05 — PagedAttention: 像操作系统管内存一样管 KV 缓存 ===\n");
+console.log(`配置: blockSize=${BLOCK_SIZE}, kvDim=${DEFAULT_CONFIG.nKVHeads * DEFAULT_CONFIG.dHead} (nKVHeads=${DEFAULT_CONFIG.nKVHeads}×dHead=${DEFAULT_CONFIG.dHead}), nLayers=${DEFAULT_CONFIG.nLayers}\n`);
+
+const model = buildModel(DEFAULT_CONFIG, 42);
+const cfg = DEFAULT_CONFIG;
+
+// =============================================================================
+// (a) memory: contiguous-reserved vs paged + internal fragmentation
+// =============================================================================
+// We model a realistic concurrent batch: each request has a different actual length
+// (the 3 PROMPTS), but a contiguous cache must reserve maxSeq for each (it cannot
+// know the final length, and it grows one flat array it dare not re-grow per token in
+// production). Paged reserves only the blocks each length actually touches.
+console.log("[a] 内存占用: 连续预留 vs 分页 (同一批并发请求)\n");
+
+// bytes per single cached position across all layers (K+V), = estimateKVBytes(_,1,1).
+const bytesPerPos = estimateKVBytes(cfg, 1, 1);
+const bytesPerBlock = bytesPerPos * BLOCK_SIZE;
+
+const reqLens = PROMPTS.map((p) => encode(p).length); // [3, 48, 235]
+console.log(`    并发请求实际长度 = [${reqLens.join(", ")}] tokens`);
+
+// contiguous: every request reserves maxSeq positions.
+const contiguousBytes = reqLens.length * estimateKVBytes(cfg, cfg.maxSeq, 1);
+// paged: every request reserves ceil(len/blockSize) blocks.
+let pagedBytes = 0;
+let usefulBytes = 0;
+for (const len of reqLens) {
+  pagedBytes += blocksNeeded(len) * bytesPerBlock;
+  usefulBytes += len * bytesPerPos;
+}
+// internal fragmentation = reserved-but-unused / reserved.
+const fragContig = 1 - usefulBytes / contiguousBytes;
+const fragPaged = 1 - usefulBytes / pagedBytes;
+
+console.log(`    实际用到的 KV (3 请求合计) = ${formatBytes(usefulBytes)} (est.)`);
+console.log(`    连续预留 (每请求占 maxSeq=${cfg.maxSeq}) = ${formatBytes(contiguousBytes)} (est.), 内部碎片 = ${(fragContig * 100).toFixed(1)}%`);
+console.log(`    分页预留 (每请求占 ceil(len/${BLOCK_SIZE}) 块) = ${formatBytes(pagedBytes)} (est.), 内部碎片 = ${(fragPaged * 100).toFixed(1)}%`);
+console.log(`    分页相对连续节省 = ${(contiguousBytes / pagedBytes).toFixed(1)}x 内存\n`);
+
+// =============================================================================
+// (b) capacity: fixed VRAM budget -> max concurrent requests
+// =============================================================================
+// Same budget, two allocators. Assume the typical in-flight request has decoded to
+// some working length (not maxSeq). Contiguous still must reserve maxSeq per slot;
+// paged reserves only the blocks for the working length. The capacity gap IS the gap
+// between "reserve worst case" and "reserve what you use".
+console.log("[b] 固定显存预算下的最大并发请求数\n");
+const budgetBytes = 64 * 1024 * 1024; // 64 MiB toy budget; ratios are budget-independent
+const workingLen = 64; // a representative mid-flight sequence length
+const contigPerReq = estimateKVBytes(cfg, cfg.maxSeq, 1); // must reserve maxSeq
+const pagedPerReq = blocksNeeded(workingLen) * bytesPerBlock; // only the touched blocks
+const maxContig = Math.floor(budgetBytes / contigPerReq);
+const maxPaged = Math.floor(budgetBytes / pagedPerReq);
+console.log(`    预算 = ${formatBytes(budgetBytes)} (est.), 代表性工作长度 = ${workingLen} tokens`);
+console.log(`    连续: 每请求预留 maxSeq=${cfg.maxSeq} -> ${formatBytes(contigPerReq)}/请求 -> 最多 ${maxContig} 并发`);
+console.log(`    分页: 每请求只占 ${blocksNeeded(workingLen)} 块 -> ${formatBytes(pagedPerReq)}/请求 -> 最多 ${maxPaged} 并发`);
+console.log(`    分页并发能力 = 连续的 ${(maxPaged / maxContig).toFixed(1)}x\n`);
+
+// =============================================================================
+// (c) correctness: paged logits == contiguous/reference, drift == 0
+// =============================================================================
+// The load-bearing invariant. Paging only moves bytes around; the logits must be
+// bit-identical to BOTH the reference forwardNoCache and the contiguous forwardStep.
+// We check all 3 prompts (avoid N=1) — a paging bug often hides until a sequence
+// crosses a block boundary, which the 48- and 235-token prompts both do.
+console.log("[c] 正确性: 分页注意力 logits 逐位对拍 (drift 必须 ≈0)\n");
+let worstDrift = 0;
+for (const p of PROMPTS) {
+  const ids = encode(p);
+  const refLogits = Array.from(forwardNoCache(model, ids)); // O(seq^2) reference
+
+  const contigCache = newCache(cfg);
+  let contigLast: Float64Array = new Float64Array(cfg.vocabSize);
+  for (const id of ids) contigLast = forwardStep(model, id, contigCache);
+
+  const pool = newPool(cfg);
+  const { lastLogits: pagedLast } = pagedPrefill(model, ids, pool);
+
+  const dRef = maxLogitDrift(refLogits, Array.from(pagedLast));
+  const dContig = maxLogitDrift(Array.from(contigLast), Array.from(pagedLast));
+  worstDrift = Math.max(worstDrift, dRef, dContig);
+  const nBlocks = blocksNeeded(ids.length);
+  console.log(
+    `    len=${String(ids.length).padStart(3)} (跨${nBlocks}块): drift vs reference=${dRef.toExponential(2)}, vs contiguous=${dContig.toExponential(2)}, argmax match=${argmax(pagedLast) === argmax(refLogits)}`
+  );
+}
+console.log(`    最坏 drift = ${worstDrift.toExponential(2)} -> ${worstDrift === 0 ? "分页不改变任何输出 (bit-for-bit)" : "WARNING: 分页引入了漂移!"}\n`);
+
+// =============================================================================
+// (d) prefix sharing: many requests share one system-prompt prefix
+// =============================================================================
+// The killer app of paging: a shared system prompt lives in physical blocks ONCE,
+// and every request's block table points at those same blocks. Saves the memory of
+// N-1 copies AND the prefill compute for the shared span (we only run it once).
+console.log("[d] prefix 共享: 多个请求共享同一 system prompt 前缀\n");
+const systemPrompt = "You are a helpful assistant. Answer concisely and cite sources.";
+const userQueries = [" What is paging?", " Explain GQA.", " Why subtract softmax max?", " Define TTFT."];
+const sysIds = encode(systemPrompt);
+const nReq = userQueries.length;
+// shared prefix must end on a block boundary to be shareable as whole blocks — this
+// is a real paged-cache constraint (vLLM shares only full blocks). We share the
+// floor-aligned prefix; the tail of the prompt that doesn't fill a block is per-req.
+const sharedBlocks = Math.floor(sysIds.length / BLOCK_SIZE);
+const sharedLen = sharedBlocks * BLOCK_SIZE;
+
+const sharedPool = newPool(cfg);
+// Prefill the shared prefix ONCE into its own sequence; its first `sharedBlocks`
+// physical blocks become the shared region every request will alias.
+const sysSeq: PagedSeq = { blockTable: [], len: 0 };
+const sharedPrefillMs = timeIt(() => {
+  for (const id of sysIds) pagedStep(model, id, sysSeq, sharedPool);
+});
+const sharedPhysBlocks = sysSeq.blockTable.slice(0, sharedBlocks);
+
+// Each request: alias the shared blocks (no compute, no new memory), then prefill
+// only the NON-shared remainder (system tail + its own query).
+// warmup the per-request path once (timeIt convention) before measuring.
+{
+  const warm: PagedSeq = { blockTable: [...sharedPhysBlocks], len: sharedLen };
+  const tail = sysIds.slice(sharedLen).concat(encode(userQueries[0]));
+  for (const id of tail) pagedStep(model, id, warm, sharedPool);
+}
+let perReqPrefillMs = 0;
+let sharedBlocksAliased = 0;
+for (const q of userQueries) {
+  const seq: PagedSeq = { blockTable: [...sharedPhysBlocks], len: sharedLen };
+  sharedBlocksAliased += sharedPhysBlocks.length;
+  const tail = sysIds.slice(sharedLen).concat(encode(q));
+  perReqPrefillMs += timeIt(() => {
+    for (const id of tail) pagedStep(model, id, seq, sharedPool);
+  });
+}
+
+// memory: shared (prefix once + N tails) vs naive (N full copies of the prefix).
+const tailLensSum = userQueries.reduce((acc, q) => acc + blocksNeeded(sysIds.length - sharedLen + encode(q).length), 0);
+const sharedMemBlocks = sharedBlocks + tailLensSum; // prefix blocks counted once
+const naiveMemBlocks = nReq * blocksNeeded(sysIds.length) + userQueries.reduce((acc, q) => acc + blocksNeeded(encode(q).length), 0);
+console.log(`    system prompt = ${sysIds.length} tokens -> 可共享 ${sharedBlocks} 个整块 (${sharedLen} tokens), 余 ${sysIds.length - sharedLen} tokens 不满整块`);
+console.log(`    ${nReq} 个请求, 每个别名同 ${sharedPhysBlocks.length} 个物理块 (共 ${sharedBlocksAliased} 次别名, 0 拷贝)`);
+console.log(`    内存: 共享 ${sharedMemBlocks} 块 vs 朴素各存一份 ${naiveMemBlocks} 块 -> 省 ${formatBytes((naiveMemBlocks - sharedMemBlocks) * bytesPerBlock)} (est.)`);
+// prefill compute: shared prefix run once vs once-per-request.
+const naivePrefillMsEst = sharedPrefillMs * nReq + perReqPrefillMs; // est.: N full prefixes + tails
+const sharedTotalPrefillMs = sharedPrefillMs + perReqPrefillMs; // measured: 1 prefix + N tails
+console.log(`    prefill 时间: 共享 = ${sharedTotalPrefillMs.toFixed(2)}ms (前缀1次 ${sharedPrefillMs.toFixed(2)}ms + ${nReq}尾巴 ${perReqPrefillMs.toFixed(2)}ms)`);
+console.log(`                  朴素 ≈ ${naivePrefillMsEst.toFixed(2)}ms (est.: 前缀重算${nReq}次), 加速 = ${speedup(naivePrefillMsEst, sharedTotalPrefillMs).toFixed(2)}x\n`);
+
+// =============================================================================
+// (e) FAILURE MODE: corrupted block table -> reads another request's KV
+// =============================================================================
+// Paging's new hazard: the block table is an indirection, and a wrong entry doesn't
+// crash — it silently makes attention read a DIFFERENT request's keys/values. The
+// output is plausible garbage (cross-request contamination), the worst kind of bug.
+// We force it: build two independent sequences in one pool, then corrupt request B's
+// block table to point a logical block at request A's physical block, and show the
+// logits drift away from B's correct output.
+console.log("[e] 失败模式: block table 映射错位 -> 读到别的请求的 KV (logits 污染)\n");
+const poolE = newPool(cfg);
+const idsA = encode("AAAAAAAAAAAAAAAA"); // request A: distinct content
+const idsB = encode("zzzzzzzzzzzzzzzz"); // request B: different content, same length
+
+const { seq: seqA } = pagedPrefill(model, idsA, poolE);
+const { seq: seqB, lastLogits: correctB } = pagedPrefill(model, idsB, poolE);
+
+// Corrupt B's block table: redirect its logical block 0 to A's physical block 0.
+// Now B's attention over its first BLOCK_SIZE positions reads A's K/V. This is the
+// exact bug a block-allocator off-by-one or a refcount race would produce.
+const goodPhys = seqB.blockTable[0];
+seqB.blockTable[0] = seqA.blockTable[0]; // <-- the corruption
+// Re-run B's last step to recompute its logits under the poisoned table. We rebuild
+// B's logits by replaying its tokens through the (now corrupted) block table without
+// re-writing K/V: do a read-only final step by re-gathering. Simplest faithful way:
+// re-derive last-token logits via a fresh step that re-reads history from blocks.
+const poisonedSeq: PagedSeq = { blockTable: seqB.blockTable, len: idsB.length - 1 };
+const poisonedLast = pagedStep(model, idsB[idsB.length - 1], poisonedSeq, poolE);
+const poisonDrift = maxLogitDrift(Array.from(correctB), Array.from(poisonedLast));
+console.log(`    请求 B 正确 argmax = ${argmax(correctB)}`);
+console.log(`    block table 错位后 B 的 argmax = ${argmax(poisonedLast)} ${argmax(poisonedLast) !== argmax(correctB) ? "(被污染, 变了!)" : "(本例恰好未翻转, 但 logits 已偏移)"}`);
+console.log(`    logits 漂移 = ${poisonDrift.toExponential(2)} (≫0: 读到了 A 的 KV, 输出被污染)`);
+seqB.blockTable[0] = goodPhys; // restore, lest a later reader trust the corrupted table
+console.log(`    教训: 分页用一层间接换效率, 代价是 block table 必须永远正确 — 一个错条目=静默串话, 不崩溃, 最难查\n`);
+
+console.log("=== stage05 完成: 分页省内存/增并发/可共享前缀, 且证明不改变输出 (drift=0) ===");

--- a/examples/llm-inference-from-scratch/src/stage06-speculative.ts
+++ b/examples/llm-inference-from-scratch/src/stage06-speculative.ts
@@ -1,0 +1,689 @@
+// stage06-speculative.ts — speculative decoding: a cheap DRAFT model races ahead
+// proposing K tokens, the expensive TARGET model verifies all K in one pass, and a
+// rejection-sampling accept rule guarantees the output is sampled from EXACTLY the
+// target's distribution — not an approximation, the same distribution.
+//
+// The single idea worth internalizing: speculative decoding is a LATENCY trick, not a
+// quality trick. It does no less target work per accepted token in the worst case, but
+// it amortizes target forward passes across a run of cheap guesses, so when the draft
+// happens to agree with the target you pay one target pass for several tokens. The
+// accept rule is constructed so the marginal output distribution is provably identical
+// to vanilla target sampling (Leviathan et al. 2023 / Chen et al. 2023). That theorem
+// is the whole reason this is safe to ship — and section (a) verifies it empirically.
+//
+// A subtlety this stage takes seriously: equivalence is DISTRIBUTIONAL, not per-seed.
+// Speculative decoding draws MORE random numbers than plain sampling (accept coins,
+// residual resamples), so under a shared seed the two do NOT emit the same sequence —
+// the naive "same seed -> same tokens" test is WRONG and would falsely fail. The
+// correct test is: (a1) at temperature->0 both are deterministic argmax, so sequences
+// must match exactly; (a2) at temperature 1, the empirical token distribution over many
+// independent runs must match (KL -> 0). Both are checked below.
+//
+// Honest-numbers caveat (inherited from core/metrics): toy model, unoptimized float64
+// kernels, so ABSOLUTE tok/s is pessimistic and the draft-vs-target cost ratio is toy-
+// optimistic (the draft is a shallow truncation of the SAME weights, not a separate
+// trained net). What transfers to a real engine: the SHAPE of speedup vs acceptance vs
+// K, the existence of a sweet-spot K, and the negative-optimization cliff under
+// draft/target misalignment. Treat absolute multipliers as illustrative.
+//
+// Determinism: every random choice is driven by a seeded mulberry32 PRNG, so all
+// reported numbers are reproducible run-to-run.
+
+import {
+  DEFAULT_CONFIG,
+  type ModelConfig,
+  type Model,
+  type KVCache,
+  buildModel,
+  forwardStep,
+  mulberry32,
+  newCache,
+} from "./core/model.js";
+import { encode, PROMPTS, VOCAB_SIZE } from "./core/tokenizer.js";
+import { softmax, tensor } from "./core/tensor.js";
+import { timeIt, tokensPerSecond, argmax } from "./core/metrics.js";
+
+// --- sampling primitives ------------------------------------------------------
+//
+// Two decoding regimes, both exercised below:
+//   - GREEDY (argmax): deterministic. Speculative greedy decoding accepts proposed[j]
+//     iff it equals the target's argmax; this is provably bit-for-bit identical to greedy
+//     target-only for ANY draft, which is section a1's exact-sequence test.
+//   - SAMPLING (temperature): stochastic. Here the correctness theorem is distributional;
+//     section a2 verifies it via empirical KL. Temperature shapes how peaked the target is
+//     and thus directly shapes acceptance (a peaky target is easy for any draft to hit).
+//
+// Why NOT fake greedy with a tiny temperature: in this toy model the top-2 logit gap is
+// small (the runner-up still holds ~10% mass even at temperature 0.02), so low-temperature
+// SAMPLING is not deterministic and would make the a1 exact-match test spuriously fail.
+// Greedy must be a real argmax path, not a temperature limit.
+
+// Logit row -> probability distribution at a temperature (>0 so the division stays finite).
+function softmaxProbs(logits: Float64Array, temperature: number): Float64Array {
+  const scaled = new Float64Array(logits.length);
+  const invT = 1 / temperature;
+  for (let i = 0; i < logits.length; i++) scaled[i] = logits[i] * invT;
+  return softmax(tensor(scaled, [1, logits.length])).data;
+}
+
+// Sample a token id from a distribution with one PRNG draw (inverse-CDF walk). The
+// trailing fallback guards floating-point rounding where the cumulative sum stops just
+// short of u; without it a u≈1 could fall through and silently bias toward token 0.
+function sampleFromProbs(probs: Float64Array, rng: () => number): number {
+  const u = rng();
+  let acc = 0;
+  for (let i = 0; i < probs.length; i++) {
+    acc += probs[i];
+    if (u < acc) return i;
+  }
+  return probs.length - 1;
+}
+
+// KL(p || q) in nats, used to PROVE distributional equivalence (section a2). We add a
+// tiny epsilon to q so a zero-probability bin in an empirical histogram doesn't blow up
+// to infinity — the smoothing is uniform and tiny, so a genuinely-different distribution
+// still registers a clearly non-zero KL while two matching ones land near 0.
+function klDivergence(p: number[], q: number[]): number {
+  const eps = 1e-9;
+  let kl = 0;
+  for (let i = 0; i < p.length; i++) {
+    if (p[i] <= 0) continue;
+    kl += p[i] * Math.log(p[i] / (q[i] + eps));
+  }
+  return kl;
+}
+
+// --- KV cache rollback --------------------------------------------------------
+//
+// THE load-bearing mechanism, and the part every from-scratch implementation gets
+// wrong first. Both the target and draft caches must, at the boundary between rounds,
+// represent EXACTLY `prompt + committed output` — no more. During a round the draft
+// grows by k proposals and the target grows by k verifications; tokens past the
+// accepted prefix are conditioned on guesses we threw away, so their cache rows are
+// poison. We slice each layer's flat [len*kvDim] buffer back to [keep*kvDim] (the exact
+// inverse of forwardStep's per-step growth) and reset len, the single source of truth
+// for position. Skip cache poisoning and the next forward attends over garbage and the
+// distributional-equivalence guarantee silently breaks.
+function rollbackCache(cache: KVCache, keep: number, cfg: ModelConfig): void {
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+  for (let l = 0; l < cfg.nLayers; l++) {
+    cache.k[l] = cache.k[l].slice(0, keep * kvDim);
+    cache.v[l] = cache.v[l].slice(0, keep * kvDim);
+  }
+  cache.len = keep;
+}
+
+// --- draft model: a shallow truncation of the target -------------------------
+//
+// A real engine pairs a big target with a separately-trained small draft. We can't
+// train, so we approximate "small aligned draft" by truncating the target to its first
+// nLayers from the SAME seed — a genuinely cheaper network (fewer matmuls) sharing the
+// target's lower-layer representations, so it agrees with the target often. Draft
+// QUALITY is then a dial: more draft layers -> closer to target -> higher acceptance.
+// Misalignment (section d) is produced from a DIFFERENT seed: same shape, uncorrelated
+// weights, so predictions decorrelate and acceptance collapses.
+function buildDraftModel(draftLayers: number, seed: number): Model {
+  const cfg: ModelConfig = { ...DEFAULT_CONFIG, nLayers: draftLayers };
+  return buildModel(cfg, seed);
+}
+
+const TARGET_LAYERS = DEFAULT_CONFIG.nLayers; // 4
+
+// Decoding regime. Greedy is deterministic (argmax, no PRNG); sample draws from the
+// temperature-scaled distribution. Both target-only and speculative honor the same regime
+// so their outputs are comparable (exact for greedy, distributional for sampling).
+type DecodeMode = { kind: "greedy" } | { kind: "sample"; temperature: number };
+
+// Pick the next token from logits under a regime. Returns the token; for sampling it
+// consumes one PRNG draw, for greedy it consumes none (so greedy is fully deterministic).
+function pickToken(logits: Float64Array, mode: DecodeMode, rng: () => number): number {
+  if (mode.kind === "greedy") return argmax(logits);
+  return sampleFromProbs(softmaxProbs(logits, mode.temperature), rng);
+}
+
+// --- target-only baseline (the thing we must match + beat) --------------------
+//
+// Plain autoregressive decode from the target: one target forward per generated token.
+// Returns the sequence AND the number of target forwards (the cost unit speculative
+// decoding tries to shrink).
+function generateTargetOnly(
+  target: Model,
+  promptIds: number[],
+  nNewTokens: number,
+  mode: DecodeMode,
+  seed: number
+): { tokens: number[]; targetForwards: number } {
+  const rng = mulberry32(seed);
+  const cache = newCache(target.cfg);
+  // annotate as plain Float64Array (not the ArrayBuffer-narrowed `new` type) so reassignment
+  // from forwardStep type-checks under @types/node 22 — same fix core/model applies.
+  let lastLogits: Float64Array = new Float64Array(VOCAB_SIZE);
+  for (const id of promptIds) lastLogits = forwardStep(target, id, cache);
+  let targetForwards = promptIds.length;
+
+  const out: number[] = [];
+  for (let i = 0; i < nNewTokens; i++) {
+    const tok = pickToken(lastLogits, mode, rng);
+    out.push(tok);
+    lastLogits = forwardStep(target, tok, cache);
+    targetForwards++;
+  }
+  return { tokens: out, targetForwards };
+}
+
+type SpecResult = {
+  tokens: number[];
+  // targetForwards: SERIAL per-position target evaluations this toy actually runs. Honest
+  // for THIS implementation's wall-clock, but NOT the metric a real engine optimizes.
+  targetForwards: number;
+  // targetPasses: number of target VERIFICATION PASSES (one per round, regardless of k). On
+  // real hardware a pass verifies all k+1 positions in ONE batched forward, so this — not
+  // targetForwards — is the transferable cost. The algorithmic speedup is N / targetPasses
+  // (decode), because plain decoding needs one full target pass PER token.
+  targetPasses: number;
+  draftForwards: number;
+  acceptedDraftTokens: number;
+  proposedDraftTokens: number;
+  rounds: number;
+};
+
+// --- speculative decoding -----------------------------------------------------
+//
+// Cross-round invariant (the contract that makes everything correct):
+//   - tCache and dCache each hold exactly the committed tokens [prompt + out], every row
+//     valid (tCache.len == dCache.len == promptIds.length + out.length).
+//   - targetLast / draftLast hold each model's next-token distribution GIVEN that committed
+//     history (i.e. the distribution predicting the token at index = committed length).
+//
+// One round, with C = committed length at entry (greedy and sampling regimes unified):
+//   1. DRAFT proposes k tokens autoregressively starting from draftLast (k-1 draft
+//      forwards; the k-th distribution is not needed). Draft cache grows.
+//   2. TARGET verifies: if a boundary token from the previous round is PENDING (its target
+//      cache row was deferred), feed it FIRST — this both creates its row and yields the
+//      logits for proposed[0], so the boundary token costs the target ZERO extra forwards.
+//      Then feed proposed[0..k-1]. targetLogitAt has length k+1.
+//   3. ACCEPT/REJECT left to right:
+//        greedy   — accept proposed[j] iff it equals argmax(target logits at j); on the
+//                   first miss, commit the target's argmax and STOP.
+//        sampling — accept with prob min(1, p_t/p_d); on the first reject, resample from
+//                   the residual norm((p_t - p_d)_+) and STOP.
+//      Both rules are exactly the construction that makes the committed token's law equal
+//      the target's law at that position (greedy: identical token; sampling: identical dist).
+//   4. If ALL k accepted, the verification's last distribution yields a FREE bonus token —
+//      best case k+1 committed tokens for one verification pass.
+//   5. REPAIR: roll the target cache back to the last position whose row is valid (the
+//      accepted proposals; the boundary token's row is DEFERRED to next round's step 2),
+//      and roll/extend the draft cache so draftLast predicts the position after the boundary
+//      token. The deferred-boundary trick is the standard fusion that makes a real engine do
+//      ~one target forward per *committed* token (fewer when accepting), not one per round
+//      extra — without it speculation would do MORE target work than plain decoding here.
+function generateSpeculative(
+  target: Model,
+  draft: Model,
+  promptIds: number[],
+  nNewTokens: number,
+  K: number,
+  mode: DecodeMode,
+  seed: number
+): SpecResult {
+  const rng = mulberry32(seed);
+  const tCache = newCache(target.cfg);
+  const dCache = newCache(draft.cfg);
+  // Prefill the draft fully (its draftLast predicts the first generated position). The
+  // target prefill stops ONE token early: the last prompt token is left "pending" so it
+  // becomes the first verification step of round 1 — keeping the deferred-boundary path
+  // (which dominates every later round) the single, uniform code path. tCache ends at
+  // promptLen-1, dCache at promptLen.
+  let draftLast: Float64Array = new Float64Array(VOCAB_SIZE);
+  for (let i = 0; i < promptIds.length; i++) {
+    if (i < promptIds.length - 1) {
+      forwardStep(target, promptIds[i], tCache);
+    }
+    draftLast = forwardStep(draft, promptIds[i], dCache);
+  }
+  let targetForwards = promptIds.length - 1;
+  let targetPasses = 0; // verification passes (prefill is not a verification round)
+  let draftForwards = promptIds.length;
+  // pendingToken: a committed token whose target cache row + successor logits are deferred
+  // to the next round's first verification step. Invariant: tCache holds [prompt+out] minus
+  // this one token; dCache holds all of [prompt+out].
+  let pendingToken = promptIds[promptIds.length - 1];
+
+  const out: number[] = [];
+  let acceptedDraftTokens = 0;
+  let proposedDraftTokens = 0;
+  let rounds = 0;
+
+  while (out.length < nNewTokens) {
+    rounds++;
+    const k = Math.min(K, nNewTokens - out.length); // never propose past requested length
+
+    // --- 1. DRAFT proposes k tokens from draftLast --------------------------------
+    // Retain each proposal's source LOGITS (not probs) so the accept rule can compute probs
+    // at the target temperature, or take an argmax, without recomputing the forward. We step
+    // ALL k proposals into the draft cache (including the last) so the accepted prefix always
+    // has valid draft rows for the cheap draft-side repair in step 5.
+    const draftBaseLen = dCache.len; // proposed[j] occupies draft cache row draftBaseLen+j
+    const proposed: number[] = [];
+    const draftLogitAt: Float64Array[] = [];
+    let dLogits = draftLast;
+    for (let j = 0; j < k; j++) {
+      draftLogitAt.push(dLogits);
+      const tok = pickToken(dLogits, mode, rng);
+      proposed.push(tok);
+      proposedDraftTokens++;
+      dLogits = forwardStep(draft, tok, dCache); // step all k so accepted rows always exist
+      draftForwards++;
+    }
+
+    // --- 2. TARGET verifies (pending token first, for free) -----------------------
+    // Feeding pendingToken creates its deferred cache row AND produces the logits for
+    // proposed[0] — so the pending/boundary token never costs a dedicated target forward.
+    // Then proposed[0..k-1]. After this, tCache holds the pending token + all k proposals.
+    targetPasses++; // ONE verification pass per round (k+1 positions; batched on real HW)
+    const verifyBaseLen = tCache.len; // == committed-pending length; first valid row index
+    const targetLogitAt: Float64Array[] = [];
+    let tLogits = forwardStep(target, pendingToken, tCache);
+    targetForwards++;
+    targetLogitAt.push(tLogits); // logits at the position of proposed[0]
+    for (let j = 0; j < k; j++) {
+      tLogits = forwardStep(target, proposed[j], tCache);
+      targetForwards++;
+      targetLogitAt.push(tLogits);
+    }
+
+    // --- 3. ACCEPT / REJECT walk -------------------------------------------------
+    let accepted = 0;
+    let boundaryToken = -1; // resampled/argmax (reject) or bonus (all-accept) token
+    for (let j = 0; j < k; j++) {
+      const tok = proposed[j];
+      if (mode.kind === "greedy") {
+        // greedy speculative: accept iff the draft's argmax matches the target's argmax.
+        if (tok === argmax(targetLogitAt[j])) {
+          out.push(tok);
+          accepted++;
+          acceptedDraftTokens++;
+        } else {
+          boundaryToken = argmax(targetLogitAt[j]); // commit the target's own choice
+          out.push(boundaryToken);
+          break;
+        }
+      } else {
+        // sampling speculative: rejection sampling against the target distribution.
+        const pT_all = softmaxProbs(targetLogitAt[j], mode.temperature);
+        const pD_all = softmaxProbs(draftLogitAt[j], mode.temperature);
+        // accept with prob min(1, pT/pD). pD>0 always (proposed[j] was sampled from pd).
+        const acceptProb = pD_all[tok] > 0 ? Math.min(1, pT_all[tok] / pD_all[tok]) : 1;
+        if (rng() < acceptProb) {
+          out.push(tok);
+          accepted++;
+          acceptedDraftTokens++;
+        } else {
+          // first rejection: resample from residual norm((p_t - p_d)_+). This removes the
+          // mass the draft over-proposed and lands on the mass it under-proposed — exactly
+          // what makes the committed token's distribution equal the target's.
+          const residual = new Float64Array(VOCAB_SIZE);
+          let sum = 0;
+          for (let t = 0; t < VOCAB_SIZE; t++) {
+            const r = pT_all[t] - pD_all[t];
+            const rr = r > 0 ? r : 0;
+            residual[t] = rr;
+            sum += rr;
+          }
+          if (sum > 1e-12) {
+            for (let t = 0; t < VOCAB_SIZE; t++) residual[t] /= sum;
+          } else {
+            residual.set(pT_all); // degenerate residual -> fall back to p_target directly
+          }
+          boundaryToken = sampleFromProbs(residual, rng);
+          out.push(boundaryToken);
+          break;
+        }
+      }
+    }
+    // --- 4. all k accepted -> free bonus token from the verification's last dist ----
+    if (accepted === k && out.length < nNewTokens) {
+      boundaryToken = pickToken(targetLogitAt[k], mode, rng);
+      out.push(boundaryToken);
+    }
+
+    // --- 5. REPAIR caches + set up the deferred boundary token ---------------------
+    // Target valid rows after verification: the pending token (at verifyBaseLen) plus the
+    // accepted proposals at verifyBaseLen+1 .. verifyBaseLen+accepted. Roll off the rest
+    // (rejected proposals / unused verification rows). The boundary token's row is NOT
+    // written now — it becomes next round's pending token (step 2 writes it for free).
+    rollbackCache(tCache, verifyBaseLen + 1 + accepted, target.cfg);
+    if (boundaryToken < 0) break; // hit nNewTokens exactly with a full accept; done.
+    pendingToken = boundaryToken;
+    // Draft cache: keep the accepted proposals' rows (draftBaseLen .. draftBaseLen+accepted),
+    // drop the rejected ones, then feed the boundary token to get draftLast + its row. Draft
+    // repair stays on the (cheap) draft — only the expensive TARGET forward is fused/deferred.
+    rollbackCache(dCache, draftBaseLen + accepted, draft.cfg);
+    draftLast = forwardStep(draft, boundaryToken, dCache);
+    draftForwards++;
+  }
+
+  return {
+    tokens: out.slice(0, nNewTokens),
+    targetForwards,
+    targetPasses,
+    draftForwards,
+    acceptedDraftTokens,
+    proposedDraftTokens,
+    rounds,
+  };
+}
+
+// --- synthetic-alignment acceptance probe -------------------------------------
+//
+// Why this exists: in an UNTRAINED toy model every next-token distribution is nearly flat,
+// so the accept rule min(1, p_t/p_d) returns a high value for ALMOST ANY draft — even a
+// random-weight one. That makes the layer-depth "draft quality" dial too weak to move
+// acceptance, and would make the failure-mode demo dishonest (a random draft would appear
+// to "work"). To show the real relationship — acceptance RISES with alignment and COLLAPSES
+// without it — we drive a DRAFT distribution we fully control:
+//
+//     p_draft = normalize( alpha * p_target  +  (1 - alpha) * uniform )
+//
+// alpha is the alignment dial: alpha=1 -> draft==target -> accept ~100%; alpha=0 -> draft is
+// uniform noise -> accept collapses. This is faithful to the mechanism (a better-aligned
+// draft is, by definition, one whose distribution is closer to the target's); we are simply
+// dialing that closeness directly instead of hoping a toy truncation produces it. It uses the
+// target's own per-step distribution (computed by running the target), so there is no second
+// model — we measure ACCEPTANCE only here, not speed.
+function measureSyntheticAcceptance(
+  target: Model,
+  promptIds: number[],
+  nRounds: number,
+  K: number,
+  alpha: number,
+  temperature: number,
+  seed: number
+): { acceptRate: number; meanAcceptedPerRound: number; rounds: number } {
+  const rng = mulberry32(seed);
+  const uniform = 1 / VOCAB_SIZE;
+  // Cap decode positions per episode well under cfg.maxSeq so the KV cache never overflows
+  // (forwardStep throws at maxSeq). We run many short episodes — each reseeds the target from
+  // the prompt — to gather nRounds samples without exceeding the position limit.
+  const maxDecodePerEpisode = Math.max(8, target.cfg.maxSeq - promptIds.length - K - 2);
+
+  let proposedTotal = 0;
+  let acceptedTotal = 0;
+  let rounds = 0;
+
+  while (rounds < nRounds) {
+    const cache = newCache(target.cfg);
+    let lastLogits: Float64Array = new Float64Array(VOCAB_SIZE); // widen for forwardStep reassign
+    for (const id of promptIds) lastLogits = forwardStep(target, id, cache);
+
+    let produced = 0;
+    while (rounds < nRounds && produced < maxDecodePerEpisode) {
+      rounds++;
+      // Draft distribution from the current target distribution; propose K tokens i.i.d. from
+      // it (a stateless draft is sufficient to probe per-position acceptance).
+      const pT = softmaxProbs(lastLogits, temperature);
+      const pD = new Float64Array(VOCAB_SIZE);
+      for (let t = 0; t < VOCAB_SIZE; t++) pD[t] = alpha * pT[t] + (1 - alpha) * uniform;
+      // (already normalized: alpha*sum(pT) + (1-alpha)*1 = 1)
+
+      let accepted = 0;
+      for (let j = 0; j < K; j++) {
+        const tok = sampleFromProbs(pD, rng);
+        proposedTotal++;
+        const acceptProb = pD[tok] > 0 ? Math.min(1, pT[tok] / pD[tok]) : 1;
+        if (rng() < acceptProb) {
+          accepted++;
+          acceptedTotal++;
+        } else {
+          break; // first reject ends the round (matches generateSpeculative)
+        }
+      }
+      // committed = accepted + 1 boundary token; advance the target one real step so the next
+      // round's distribution is a fresh position (keeps the probe non-degenerate).
+      produced += accepted + 1;
+      const next = sampleFromProbs(pT, rng);
+      lastLogits = forwardStep(target, next, cache);
+    }
+  }
+  return {
+    acceptRate: proposedTotal === 0 ? 0 : acceptedTotal / proposedTotal,
+    meanAcceptedPerRound: rounds === 0 ? 0 : acceptedTotal / rounds,
+    rounds,
+  };
+}
+
+// --- analysis helpers ---------------------------------------------------------
+
+function acceptanceRate(acceptedDraftTokens: number, proposedDraftTokens: number): number {
+  return proposedDraftTokens === 0 ? 0 : acceptedDraftTokens / proposedDraftTokens;
+}
+
+// ============================================================================
+// main — four required experiments, all numbers measured/computed, no asserts-only.
+// ============================================================================
+function main(): void {
+  console.log("=== stage06: 投机解码 (speculative decoding) ===\n");
+
+  const SEED_TARGET = 42;
+  const N_NEW = 48; // generated tokens per run (>> N=1 to average out luck)
+  const prompt = PROMPTS[1];
+  const promptIds = encode(prompt);
+  const target = buildModel(DEFAULT_CONFIG, SEED_TARGET);
+  console.log(
+    `model: target nLayers=${TARGET_LAYERS}, vocab=${VOCAB_SIZE}, ` +
+      `prompt len=${promptIds.length}, generate N=${N_NEW} tokens\n`
+  );
+
+  // ---- (a) DISTRIBUTION EQUIVALENCE -------------------------------------------
+  // Equivalence is distributional, NOT per-seed (speculative draws extra random numbers,
+  // so a shared seed yields different SAMPLED sequences — testing that would be a bug). Two
+  // valid proofs, one per decoding regime:
+  //   a1) GREEDY (argmax): deterministic, so the sequences must match bit-for-bit, for ANY
+  //       draft (the accept rule commits the target's argmax on every position regardless).
+  //   a2) SAMPLING (temp=1): the empirical first-token distribution over many independent
+  //       runs must match the target-only one (KL -> sampling-noise floor).
+  console.log("[a] 分布等价性 (output distribution == target-only):");
+
+  // a1: greedy regime — true argmax (NOT a tiny temperature; see softmaxProbs header).
+  const GREEDY: DecodeMode = { kind: "greedy" };
+  const goodDraft = buildDraftModel(TARGET_LAYERS, SEED_TARGET); // == target -> max alignment
+  console.log("    [a1] greedy (argmax): speculative sequence must equal target-only");
+  let allGreedyMatch = true;
+  for (const K of [2, 4, 6]) {
+    const base = generateTargetOnly(target, promptIds, N_NEW, GREEDY, 1);
+    const spec = generateSpeculative(target, goodDraft, promptIds, N_NEW, K, GREEDY, 1);
+    const identical =
+      spec.tokens.length === base.tokens.length && spec.tokens.every((t, i) => t === base.tokens[i]);
+    allGreedyMatch &&= identical;
+    const mism = spec.tokens.findIndex((t, i) => t !== base.tokens[i]);
+    console.log(
+      `         K=${K}: identical=${identical}` + (identical ? "" : `  (first mismatch @${mism})`)
+    );
+  }
+
+  // a2: sampling regime — empirical first-token histograms must match (KL ≈ noise floor).
+  // We use a weaker (depth-2) draft so acceptance is well below 100% and the residual-
+  // resample path is actually exercised; if equivalence still holds here, the accept/
+  // resample math is correct, not bypassed.
+  const TEMP: DecodeMode = { kind: "sample", temperature: 1.0 };
+  const N_RUNS = 4000;
+  const klDraft = buildDraftModel(2, SEED_TARGET);
+  const histTarget = new Array(VOCAB_SIZE).fill(0);
+  const histSpec = new Array(VOCAB_SIZE).fill(0);
+  for (let s = 0; s < N_RUNS; s++) {
+    // distinct seeds per run -> independent samples of the FIRST generated token.
+    histTarget[generateTargetOnly(target, promptIds, 1, TEMP, 1000 + s).tokens[0]]++;
+    histSpec[generateSpeculative(target, klDraft, promptIds, 1, 4, TEMP, 5000 + s).tokens[0]]++;
+  }
+  const pTarget = histTarget.map((c) => c / N_RUNS);
+  const pSpec = histSpec.map((c) => c / N_RUNS);
+  const klSpecVsTarget = klDivergence(pSpec, pTarget);
+  // baseline for scale: KL between two INDEPENDENT target-only histograms (pure sampling
+  // noise floor at this N). klSpecVsTarget should be the same order, not larger.
+  const histTarget2 = new Array(VOCAB_SIZE).fill(0);
+  for (let s = 0; s < N_RUNS; s++) {
+    histTarget2[generateTargetOnly(target, promptIds, 1, TEMP, 7000 + s).tokens[0]]++;
+  }
+  const pTarget2 = histTarget2.map((c) => c / N_RUNS);
+  const klNoiseFloor = klDivergence(pTarget2, pTarget);
+  console.log(`    [a2] sampling (temp=1, ${N_RUNS} runs): empirical first-token KL`);
+  console.log(`         KL(speculative || target-only) = ${klSpecVsTarget.toExponential(2)} nats`);
+  console.log(
+    `         KL(target-only' || target-only)  = ${klNoiseFloor.toExponential(2)} nats  (sampling noise floor)`
+  );
+  const klOk = klSpecVsTarget <= klNoiseFloor * 3 + 1e-4;
+  console.log(
+    `         speculative KL within ~noise floor: ${klOk}  ` +
+      `(equal distributions, not just equal argmax)`
+  );
+  console.log(
+    `    -> a1 sequences match=${allGreedyMatch}; a2 KL≈noise: ${klOk}. ` +
+      "Output distribution is the target's.\n"
+  );
+
+  // ---- (b) ACCEPTANCE RATE vs DRAFT QUALITY -----------------------------------
+  // We dial draft/target alignment directly (p_draft = α·p_target + (1-α)·uniform) because
+  // the untrained toy model's distributions are too flat for a layer-truncated draft to move
+  // acceptance cleanly (see measureSyntheticAcceptance header). α is the alignment dial.
+  //
+  // Temperature matters here. At temp=1 this toy's target is itself near-uniform, so even a
+  // uniform draft (α=0) "agrees" ~78% of the time — the alignment dependence is invisible.
+  // We therefore probe at temp=0.15, where the target is PEAKED (the realistic serving
+  // regime). Now α=0 genuinely collapses and the full acceptance↔alignment curve appears.
+  const PROBE_TEMP = 0.15;
+  console.log(`[b] 接受率随 draft 质量(对齐度 α)变化 (peaked temp=${PROBE_TEMP}, K=4):`);
+  console.log("    alpha   meaning                acceptRate   meanAccepted/round (of K=4)");
+  const K_B = 4;
+  for (const alpha of [0.0, 0.5, 0.9, 0.99, 1.0]) {
+    const r = measureSyntheticAcceptance(target, promptIds, 2000, K_B, alpha, PROBE_TEMP, 1);
+    const meaning =
+      alpha === 1 ? "draft = target" : alpha === 0 ? "draft = uniform noise" : "partial alignment";
+    console.log(
+      `    ${alpha.toFixed(2)}    ${meaning.padEnd(20)}   ${(r.acceptRate * 100).toFixed(1).padStart(5)}%` +
+        `        ${r.meanAcceptedPerRound.toFixed(2)}`
+    );
+  }
+  console.log(
+    "    -> acceptance rises monotonically with alignment; at α=1 every draft token is\n" +
+      "       accepted (k+1 tokens/round), at α=0 it collapses toward ~1 token/round.\n"
+  );
+
+  // ---- (c) SPEEDUP vs K (the sweet-spot) --------------------------------------
+  // CRUCIAL honesty note. The headline speedup is ALGORITHMIC: speedup = N decode steps /
+  // target VERIFICATION PASSES. Plain decoding needs one full target pass per token (N
+  // passes); speculation needs one pass per ROUND, and a round commits up to k+1 tokens, so
+  // passes < N when acceptance is decent. THAT ratio is what transfers to real hardware,
+  // where a verification pass over k+1 positions is ONE batched forward (memory-bound, ~the
+  // cost of a single decode step).
+  //
+  // This toy CANNOT show that as wall-clock: core/forwardStep verifies positions SERIALLY
+  // (k+1 sequential cached steps), so there is no batched-parallel win to measure — the very
+  // mechanism that makes speculation fast is the one absent from an unbatched reference. We
+  // print the measured wall-clock too, but it reflects serial verification and so will look
+  // slower; do not read it as the verdict. The transferable verdict is the EFF speedup column
+  // (pass count plus charged draft cost); wall-clock ms is shown only for full disclosure.
+  // Two speedup numbers per K:
+  //   ALGO   = N / targetPasses : the pure batched-verify win, IGNORING draft cost. Useful to
+  //            see the verification amortization in isolation.
+  //   EFF    = the honest one: effective cost/token = (passes + draftRatio·draftForwards)/N,
+  //            speedup = 1/that. It charges for the draft work (which shares the accelerator),
+  //            so it shows the real SWEET-SPOT: big K helps verification but the draft cost and
+  //            rising rejections eventually overtake it, so EFF peaks at a middle K and falls.
+  // We use a peaked temperature here too (temp=0.15) so acceptance actually varies with K — at
+  // temp=1 the near-uniform toy target accepts almost everything and the sweet-spot is washed out.
+  const SPEEDUP_TEMP: DecodeMode = { kind: "sample", temperature: 0.15 };
+  const DRAFT_RATIO_C = 0.25; // depth-1 draft vs depth-4 target
+  console.log(`[c] 加速比随 K 变化 (cheap aligned draft, peaked temp=0.15, draftCost=${DRAFT_RATIO_C}x):`);
+  const cDraft = buildDraftModel(1, SEED_TARGET); // 1/4 the layers -> cheaper draft
+  generateTargetOnly(target, promptIds, 8, SPEEDUP_TEMP, 1); // warmup
+  generateSpeculative(target, cDraft, promptIds, 8, 4, SPEEDUP_TEMP, 1);
+
+  const baseMs = timeIt(() => generateTargetOnly(target, promptIds, N_NEW, SPEEDUP_TEMP, 1));
+  const baseTps = tokensPerSecond(N_NEW, baseMs);
+  console.log(
+    `    target-only baseline: ${N_NEW} target passes (one per token), ${baseMs.toFixed(2)} ms serial ` +
+      `(${baseTps.toFixed(0)} tok/s)`
+  );
+  console.log("    K    acceptRate   targetPasses   ALGO speedup   EFF speedup   (serialMs)");
+  for (const K of [1, 2, 4, 6, 8, 12]) {
+    const stats = generateSpeculative(target, cDraft, promptIds, N_NEW, K, SPEEDUP_TEMP, 1);
+    const ms = timeIt(() => generateSpeculative(target, cDraft, promptIds, N_NEW, K, SPEEDUP_TEMP, 1));
+    const ar = acceptanceRate(stats.acceptedDraftTokens, stats.proposedDraftTokens);
+    const algoSp = stats.targetPasses === 0 ? Infinity : N_NEW / stats.targetPasses;
+    // effective: decode draft forwards = total draft forwards minus prefill.
+    const decodeDraftFwd = stats.draftForwards - promptIds.length;
+    const effCostPerToken = (stats.targetPasses + DRAFT_RATIO_C * decodeDraftFwd) / N_NEW;
+    const effSp = effCostPerToken > 0 ? 1 / effCostPerToken : Infinity;
+    const mark = effSp >= 1 ? "" : "  <- net slower";
+    console.log(
+      `    ${String(K).padStart(2)}   ${(ar * 100).toFixed(1).padStart(5)}%       ` +
+        `${String(stats.targetPasses).padStart(5)}         ${algoSp.toFixed(2)}x        ` +
+        `${effSp.toFixed(2)}x${mark.padEnd(14)}(${ms.toFixed(0)}ms)`
+    );
+  }
+  console.log(
+    "    -> EFF speedup (draft cost charged) is the honest verdict and it PEAKS at a middle K:\n" +
+      "       small K under-amortizes the verification pass; large K proposes tokens that get\n" +
+      "       rejected (one early reject truncates the round) while still paying their draft\n" +
+      "       cost. Serial wall-clock (ms) can't show the batched-verify win — see header note.\n"
+  );
+
+  // ---- (d) FAILURE MODE: misaligned draft -> acceptance collapse -> NEGATIVE opt ----
+  // The honest "塌到接近 0" curve needs a draft that is genuinely uncorrelated with the
+  // target. A random-WEIGHT model does NOT achieve this on a flat toy distribution (its
+  // accept rate stays misleadingly high), so we use the controlled α=0 (uniform-noise) draft.
+  // We contrast a well-aligned draft (α=0.95) against the misaligned one (α=0.0) and sweep K.
+  //
+  // The negative-optimization metric is the EFFECTIVE COST: target passes per committed token
+  // PLUS the draft work per committed token. With a real (parallel-verify) engine, one pass
+  // ≈ one decode step, so a useful regime needs (passes/token) < 1 by a margin big enough to
+  // pay for the draft. A misaligned draft drives passes/token toward 1 (no win) while still
+  // paying K draft forwards per round — net loss. Bigger K digs the hole deeper.
+  // Effective-cost model (the honest verdict). On real HW the draft runs on the same
+  // accelerator, so total cost per committed token ≈ 1 verification pass + K draft forwards,
+  // amortized over the tokens the round commits. With the draft costing DRAFT_COST_RATIO of a
+  // target pass, effective cost/token = (1 + K·ratio)/(α-acceptance·K + 1). Baseline = 1.0
+  // (one full target pass per token). Speculation HELPS iff effective cost/token < 1.
+  const DRAFT_COST_RATIO = 0.25; // a depth-1 draft vs depth-4 target (toy: ~layers ratio)
+  console.log(`[d] 失败模式: draft 与 target 对齐度对比 (peaked temp=${PROBE_TEMP}, draftCost=${DRAFT_COST_RATIO}x):`);
+  console.log("    align        K    acceptRate   effCost/token   effSpeedup   verdict");
+  for (const [label, alpha] of [
+    ["aligned α=.95", 0.95],
+    ["MISALN α=.00", 0.0],
+  ] as const) {
+    for (const K of [2, 4, 8]) {
+      const r = measureSyntheticAcceptance(target, promptIds, 2000, K, alpha, PROBE_TEMP, 1);
+      // committed/round = accepted (= acceptRate·K) + 1 boundary token.
+      const committedPerRound = r.acceptRate * K + 1;
+      const effCostPerToken = (1 + K * DRAFT_COST_RATIO) / committedPerRound;
+      const effSpeedup = 1 / effCostPerToken; // vs baseline cost 1.0/token
+      const verdict =
+        effSpeedup >= 1 ? `useful (${effSpeedup.toFixed(2)}x)` : "NEGATIVE optimization (slower)";
+      console.log(
+        `    ${label}   ${String(K).padStart(2)}    ${(r.acceptRate * 100).toFixed(1).padStart(5)}%` +
+          `        ${effCostPerToken.toFixed(2)}            ${effSpeedup.toFixed(2)}x        ${verdict}`
+      );
+    }
+  }
+  console.log(
+    "    -> aligned draft: effective cost/token < 1, a real speedup that grows with K. α=0\n" +
+      "       (uniform-noise draft): acceptance collapses (~9%), so each round commits ~1 token\n" +
+      "       yet still pays K draft forwards -> effective cost > 1 and WORSENS with K. The\n" +
+      "       sign of the optimization flips on alignment alone — that is the whole lesson.\n"
+  );
+
+  // even under misalignment the OUTPUT stays correct: run the real generateSpeculative with a
+  // genuinely bad draft (a different-seed model) in greedy mode and confirm the sequence still
+  // equals target-only. Speculation can only cost latency, never correctness.
+  const badDraft = buildModel(DEFAULT_CONFIG, 99999); // uncorrelated weights
+  const baseG = generateTargetOnly(target, promptIds, N_NEW, GREEDY, 1);
+  const badG = generateSpeculative(target, badDraft, promptIds, N_NEW, 4, GREEDY, 1);
+  const stillCorrect =
+    badG.tokens.length === baseG.tokens.length && badG.tokens.every((t, i) => t === baseG.tokens[i]);
+  console.log(`[d'] even with a TERRIBLE draft, greedy output === target-only: ${stillCorrect}`);
+  console.log("     (speculative decoding trades speed for speed, never speed for quality)\n");
+
+  console.log("=== stage06 done ===");
+}
+
+main();

--- a/examples/llm-inference-from-scratch/src/stage07-quantization.ts
+++ b/examples/llm-inference-from-scratch/src/stage07-quantization.ts
@@ -1,0 +1,344 @@
+// stage07-quantization.ts — trading precision for memory and bandwidth.
+//
+// The thesis of this stage: a weight is just a number, and you do not need 64 bits
+// to store a number whose neighbours are all roughly the same size. If a whole
+// matrix lives in [-0.3, 0.3], you can map that range onto 256 evenly-spaced int8
+// codes (or 16 int4 codes), store the tiny integers, and reconstruct an approximate
+// float on the fly. The reconstruction error is the price; 8x (int8) or 16x (int4)
+// less memory and memory *bandwidth* is what you buy. On a real GPU, decode is
+// memory-bound — the weights barely fit and must be streamed every token — so this
+// is frequently the single highest-leverage optimization in the whole engine.
+//
+// What we ACTUALLY do here (and what every "fake-quant" / simulated-quant path in a
+// real framework also does): quantize a weight to the integer grid, then immediately
+// DEQUANTIZE back to float64 and run the normal float kernels. The arithmetic the
+// model sees is the *rounded* weight. This isolates the only thing this chapter is
+// about — the numerical error quantization injects — from the orthogonal engineering
+// of int8 matmul kernels. The drift we measure is exactly the drift a true int8
+// kernel would produce, because both compute on the same rounded values.
+//
+// Four things this stage proves with real numbers:
+//   (a) memory: int8/int4 weight + KV footprint vs the float64 baseline (est.).
+//   (b) accuracy: maxLogitDrift and perplexity drift per precision — int4 worse
+//       than int8, the precision/memory trade-off curve made concrete.
+//   (c) per-tensor vs per-channel on a matrix with one planted outlier channel:
+//       per-channel rescues the outlier, per-tensor does not.
+//   (d) FAILURE MODE: per-tensor int4 + a single outlier channel -> the logits
+//       blow up (drift explodes, argmax flips), which is *why* outliers are the
+//       first and hardest problem in LLM quantization.
+//
+// Toy-data caveat (per core/metrics honesty rules): the synthetic weights are
+// near-uniform random, which is the BEST case for quantization — real LLM weights
+// have heavy tails, so absolute drift here is optimistic. What transfers is the
+// RELATIVE story: int4 > int8 drift, and per-channel >> per-tensor under outliers.
+
+import { DEFAULT_CONFIG, buildModel, forwardNoCache, type Model } from "./core/model.js";
+import { type Tensor } from "./core/tensor.js";
+import { encode, PROMPTS, VOCAB_SIZE } from "./core/tokenizer.js";
+import { estimateKVBytes, formatBytes, maxLogitDrift, perplexity, argmax } from "./core/metrics.js";
+
+// --- the quantizer ----------------------------------------------------------
+//
+// Symmetric, zero-point-free quantization: map [-absmax, +absmax] linearly onto the
+// signed integer grid [-qmax, +qmax]. Symmetric (not asymmetric/zero-point) because
+// it is the standard for weights — weights are roughly centered on 0, so spending a
+// zero-point to shift the range buys almost nothing and complicates the dequant. The
+// scale is the ONLY stored metadata per group: q = round(w / scale), w' = q * scale.
+//
+// Invariant: scale > 0 always. An all-zero group has absmax 0, which would make
+// scale 0 and produce 0/0 = NaN on dequant. We floor scale at a tiny epsilon so a
+// dead channel dequantizes to exactly 0 instead of NaN — this is a real failure mode
+// in sparse/pruned models, not a hypothetical.
+const SCALE_EPS = 1e-12;
+
+// qmax for a b-bit SIGNED integer. int8 -> 127, int4 -> 7. We use the symmetric
+// range [-qmax, qmax] (i.e. 255 of the 256 int8 codes, dropping -128) because a
+// symmetric range keeps round(0)=0 exact and avoids a lopsided quantization grid.
+function qmaxForBits(bits: number): number {
+  return (1 << (bits - 1)) - 1;
+}
+
+// Quantize then dequantize a contiguous slice of `src` in place into `dst`, using a
+// single shared scale derived from the slice's own absmax. Returns the scale (so a
+// caller can report bits-per-weight bookkeeping). This is the atom both per-tensor
+// (one call over the whole matrix) and per-channel (one call per channel) build on.
+function quantizeDequantizeSlice(
+  src: Float64Array,
+  dst: Float64Array,
+  start: number,
+  count: number,
+  stride: number,
+  qmax: number
+): number {
+  // pass 1: absmax over the slice. absmax (not std/mean) because the grid must span
+  // the most extreme value or that value clips — and a clipped weight is an
+  // unbounded error, the worst kind. This is precisely why ONE outlier poisons a
+  // whole per-tensor group: it stretches absmax so every normal weight gets a coarse
+  // grid, while per-channel confines the damage to the outlier's own channel.
+  let absmax = 0;
+  for (let i = 0; i < count; i++) {
+    const v = Math.abs(src[start + i * stride]);
+    if (v > absmax) absmax = v;
+  }
+  const scale = Math.max(absmax / qmax, SCALE_EPS);
+  // pass 2: round to grid then immediately reconstruct. Math.round is round-half-away
+  // (banker's rounding would be marginally less biased but round() matches what most
+  // integer-quant kernels emit, so the drift we report is the realistic one).
+  for (let i = 0; i < count; i++) {
+    const idx = start + i * stride;
+    const q = Math.round(src[idx] / scale);
+    // clamp into the representable grid. Without this, a value at exactly absmax that
+    // rounds to qmax is fine, but float error can push round() to qmax+1, which on a
+    // real int kernel would wrap/overflow — the clamp is the cheap insurance.
+    const qc = q > qmax ? qmax : q < -qmax ? -qmax : q;
+    dst[idx] = qc * scale;
+  }
+  return scale;
+}
+
+type QuantScheme = "per-tensor" | "per-channel";
+
+// Produce a fake-quantized copy of one weight matrix. per-tensor: one scale for the
+// whole [rows, cols] matrix. per-channel: one scale per COLUMN (output channel),
+// which is the standard weight-quant axis here — matmul is h[1,rows] @ W[rows,cols],
+// so column j is output channel j, and outlier energy in transformer weights
+// concentrates per-channel. Per-channel costs `cols` scales instead of 1; that
+// metadata overhead is real but tiny (a few floats vs the matrix) and is what makes
+// per-channel the default in practice.
+function quantizeMatrix(w: Tensor, bits: number, scheme: QuantScheme): Tensor {
+  const [rows, cols] = w.shape;
+  const out = new Float64Array(w.data.length);
+  const qmax = qmaxForBits(bits);
+  if (scheme === "per-tensor") {
+    quantizeDequantizeSlice(w.data, out, 0, rows * cols, 1, qmax);
+  } else {
+    // per column: column j is indices j, j+cols, j+2*cols, ... (row-major), so stride
+    // is `cols` and we make `cols` independent calls each with its own absmax/scale.
+    for (let j = 0; j < cols; j++) {
+      quantizeDequantizeSlice(w.data, out, j, rows, cols, qmax);
+    }
+  }
+  return { data: out, shape: [rows, cols] };
+}
+
+// Build a model whose every weight matrix is fake-quantized. RMSNorm gains are left
+// in float64 on purpose: they are O(dModel) tiny vectors (negligible memory) but
+// multiply every activation, so quantizing them buys nothing and hurts a lot — real
+// engines keep norm/scale params and often the embedding in higher precision for
+// exactly this reason. We quantize the big matmul weights, which are >99% of params.
+function quantizeModel(model: Model, bits: number, scheme: QuantScheme): Model {
+  const q = (w: Tensor) => quantizeMatrix(w, bits, scheme);
+  return {
+    cfg: model.cfg,
+    embed: q(model.embed),
+    normOut: model.normOut, // kept float64 — see note above
+    layers: model.layers.map((l) => ({
+      wQ: q(l.wQ),
+      wK: q(l.wK),
+      wV: q(l.wV),
+      wO: q(l.wO),
+      w1: q(l.w1),
+      w2: q(l.w2),
+      w3: q(l.w3),
+      normAtt: l.normAtt, // kept float64
+      normFFN: l.normFFN, // kept float64
+    })),
+  };
+}
+
+// Count the storage of a model's quantizable weights at a given bit-width, in BYTES,
+// for the memory table. This is exact arithmetic over the matrix sizes (not a
+// measurement), so it carries the (est.) label per the honesty rules. We deliberately
+// count ONLY the matmul weights (the ones quantizeModel touches) so the float64
+// baseline and the quantized number are apples-to-apples; the float64 baseline here
+// is what core stores today, and the quantized number is what an int kernel would.
+function modelWeightBytes(model: Model, bits: number): number {
+  let elems = 0;
+  const add = (w: Tensor) => (elems += w.data.length);
+  add(model.embed);
+  for (const l of model.layers) {
+    add(l.wQ); add(l.wK); add(l.wV); add(l.wO);
+    add(l.w1); add(l.w2); add(l.w3);
+  }
+  // bits/8 bytes per weight. Per-channel scales add cols*4 bytes (float32) per matrix
+  // but that is <0.5% here, so we fold it out of the headline to keep the ratio clean
+  // and note it in prose instead — overstating overhead would be its own dishonesty.
+  return Math.ceil((elems * bits) / 8);
+}
+
+// --- experiment harness -----------------------------------------------------
+//
+// Every accuracy number is computed against the SAME reference: float64 logits from
+// forwardNoCache on the prompts. forwardNoCache (not forwardStep) because we want the
+// pure model-precision effect, with zero cache machinery in the way — quantizing the
+// cache is a separate experiment below. maxLogitDrift is L∞ (catches the one
+// catastrophic logit that flips an argmax); perplexity drift catches a distribution
+// skew that argmax happens to survive. We need both: a scheme can ace one and fail
+// the other.
+
+const cfg = DEFAULT_CONFIG;
+const model = buildModel(cfg, 42);
+
+// Use ≥2 prompts (avoid N=1): the short and the long one exercise different logit
+// magnitudes. We take last-token logits per prompt as the drift sample, and the
+// full next-token logit stream of the LONG prompt for perplexity.
+const promptIdSets = [encode(PROMPTS[1]), encode(PROMPTS[2])];
+
+function refLastLogits(m: Model): number[][] {
+  return promptIdSets.map((ids) => Array.from(forwardNoCache(m, ids)));
+}
+
+// perplexity needs a stream of (logits-for-position-t, actual-token-at-t+1) pairs.
+// forwardNoCache returns only the LAST position's logits, so to get a stream we call
+// it on growing prefixes — O(seq^2) but this is an offline accuracy probe, not the
+// hot path, so clarity beats speed here.
+function ppl(m: Model, ids: number[]): number {
+  const rows: number[][] = [];
+  const targets: number[] = [];
+  for (let t = 1; t < ids.length; t++) {
+    rows.push(Array.from(forwardNoCache(m, ids.slice(0, t))));
+    targets.push(ids[t]);
+  }
+  return perplexity(rows, targets);
+}
+
+// L∞ drift of a quantized model vs the float64 reference, maxed over the prompt set —
+// max (not mean) for the same reason maxLogitDrift uses L∞: we report the worst case,
+// because the worst logit is the one that changes the output.
+function maxDriftAcross(refSets: number[][], qModel: Model): number {
+  let worst = 0;
+  const qSets = refLastLogits(qModel);
+  for (let i = 0; i < refSets.length; i++) {
+    const d = maxLogitDrift(refSets[i], qSets[i]);
+    if (d > worst) worst = d;
+  }
+  return worst;
+}
+
+console.log("=== stage07 量化 (quantization: precision for memory) ===\n");
+
+const refSets = refLastLogits(model);
+const refArgmax = refSets.map(argmax);
+const refPpl = ppl(model, promptIdSets[1]);
+
+// --- (a) memory footprint ---------------------------------------------------
+console.log("[a] 内存占用 (memory footprint, exact arithmetic -> est.):");
+const baseBytes = modelWeightBytes(model, 64); // float64 baseline = what core stores
+console.log(`    quantizable weights = ${model.embed.data.length + model.layers.reduce((s, l) => s + l.wQ.data.length + l.wK.data.length + l.wV.data.length + l.wO.data.length + l.w1.data.length + l.w2.data.length + l.w3.data.length, 0)} params`);
+for (const bits of [64, 16, 8, 4]) {
+  const b = modelWeightBytes(model, bits);
+  const label = bits === 64 ? "float64 (baseline)" : bits === 16 ? "float16" : `int${bits}`;
+  const factor = baseBytes / b;
+  console.log(`    ${label.padEnd(18)} = ${formatBytes(b).padStart(10)} (est.)  ${factor.toFixed(1)}x smaller`);
+}
+// KV cache footprint: the cache is the OTHER big memory consumer at long context, and
+// it is quantized independently (often to int8 while weights go int4). estimateKVBytes
+// assumes float64; we scale by bits/64 to show the quantized cache.
+const kvSeq = 512;
+const kvBatch = 16;
+const kvBase = estimateKVBytes(cfg, kvSeq, kvBatch);
+console.log(`\n    KV cache @ seq=${kvSeq} batch=${kvBatch}:`);
+for (const bits of [64, 16, 8, 4]) {
+  const b = Math.ceil((kvBase * bits) / 64);
+  const label = bits === 64 ? "float64 (baseline)" : bits === 16 ? "float16" : `int${bits}`;
+  console.log(`    ${label.padEnd(18)} = ${formatBytes(b).padStart(10)} (est.)  ${(kvBase / b).toFixed(1)}x smaller`);
+}
+
+// --- (b) accuracy: precision/loss curve ------------------------------------
+console.log("\n[b] 精度损失曲线 (logit drift + perplexity vs float64 baseline):");
+console.log(`    baseline: argmax=[${refArgmax.join(",")}]  PPL=${refPpl.toFixed(2)}`);
+for (const bits of [8, 4]) {
+  for (const scheme of ["per-tensor", "per-channel"] as QuantScheme[]) {
+    const qm = quantizeModel(model, bits, scheme);
+    const drift = maxDriftAcross(refSets, qm);
+    const qArgmax = refLastLogits(qm).map(argmax);
+    const qPpl = ppl(qm, promptIdSets[1]);
+    const argmaxOk = qArgmax.every((a, i) => a === refArgmax[i]);
+    console.log(
+      `    int${bits} ${scheme.padEnd(12)} drift=${drift.toExponential(2)}  PPL=${qPpl.toFixed(2)} (Δ${(qPpl - refPpl >= 0 ? "+" : "")}${(qPpl - refPpl).toFixed(2)})  argmax ${argmaxOk ? "kept" : "FLIPPED"}`
+    );
+  }
+}
+console.log("    -> int4 drifts ~10x more than int8 (15 grid levels vs 255).");
+console.log("    -> per-channel here is NOT better (slightly worse): with near-uniform");
+console.log("       weights and no outliers, every column's absmax ≈ the tensor absmax, so");
+console.log("       per-channel's extra scales just add rounding noise. Its payoff is");
+console.log("       outlier-specific — see [c]/[d].");
+
+// --- (c) per-tensor vs per-channel on a PLANTED OUTLIER ---------------------
+//
+// The headline experiment. We inflate ONE output channel (one column) of layer 0's
+// w1 — the FFN gate projection, [dModel=64, dFF=256] — by a large factor. This is a
+// synthetic stand-in for the activation/weight outliers that real LLMs are riddled
+// with (the "emergent outlier features" that make naive int8 fail on models >6.7B).
+// w1 is chosen deliberately: its 256 output channels feed SiLU -> elementwise gate ->
+// down-projection -> residual -> logits, so a corrupted channel actually reaches the
+// output (unlike a Q-projection outlier, which softmax over attention scores would
+// largely wash out). Per-channel gives that one fat channel its own scale, so the
+// other 255 keep a fine grid; per-tensor must span the outlier with a single scale,
+// coarsening every weight in the matrix.
+console.log("\n[c] per-tensor vs per-channel under a planted outlier channel:");
+const OUTLIER_COL = 3;
+const OUTLIER_FACTOR = 50; // 50x the surrounding weights — deliberately brutal
+function withOutlier(m: Model): Model {
+  // deep-copy only the matrix we mutate; share the rest (read-only downstream).
+  const w0 = m.layers[0].w1;
+  const data = Float64Array.from(w0.data);
+  const cols = w0.shape[1];
+  for (let r = 0; r < w0.shape[0]; r++) data[r * cols + OUTLIER_COL] *= OUTLIER_FACTOR;
+  const layers = m.layers.map((l, i) =>
+    i === 0 ? { ...l, w1: { data, shape: [...w0.shape] } as Tensor } : l
+  );
+  return { ...m, layers };
+}
+const outlierModel = withOutlier(model);
+// new reference: the EXACT-arithmetic outlier model in float64. Quantization error is
+// measured against this, so we isolate "how well did quant survive the outlier" from
+// "the outlier changed the model" (the latter is expected and not quant's fault).
+const outlierRef = refLastLogits(outlierModel);
+const outlierArgmax = outlierRef.map(argmax);
+for (const scheme of ["per-tensor", "per-channel"] as QuantScheme[]) {
+  const qm = quantizeModel(outlierModel, 8, scheme);
+  const drift = maxDriftAcross(outlierRef, qm);
+  const qa = refLastLogits(qm).map(argmax);
+  const kept = qa.every((a, i) => a === outlierArgmax[i]);
+  console.log(`    int8 ${scheme.padEnd(12)} drift=${drift.toExponential(2)}  argmax ${kept ? "kept" : "FLIPPED"}`);
+}
+console.log("    -> per-channel confines the outlier to its own 1/256 scale and keeps argmax;");
+console.log("       per-tensor smears it over all 256 channels and flips the output. ~7-8x gap.");
+
+// --- (d) FAILURE MODE: per-tensor int4 + outlier -> logits collapse ---------
+//
+// Push (c) to the breaking point. int4 has only 15 grid levels, so when per-tensor's
+// single scale is stretched to cover a 50x outlier, every NORMAL weight collapses onto
+// a handful of levels near zero — the matrix is effectively destroyed. The drift
+// explodes past 1.0 (logit-scale) and the argmax doesn't just flip, it lands on a
+// completely unrelated token (here [2,122] -> [212,23]: both positions wrong). Note
+// per-channel int4 ALSO flips one position — 4 bits is genuinely lossy and the toy
+// model has no error tolerance — but its drift is ~3x smaller and the corruption is
+// contained. This is the concrete reason production int4 is NEVER naive per-tensor:
+// it is always per-channel/per-group, plus dedicated outlier handling (mixed-precision
+// for outlier channels, or rotation tricks in modern quantizers). Showing the crash is
+// the point — a happy-path-only demo would hide why all that machinery exists.
+console.log("\n[d] FAILURE MODE — per-tensor int4 meets a single outlier channel:");
+const crash = quantizeModel(outlierModel, 4, "per-tensor");
+const crashDrift = maxDriftAcross(outlierRef, crash);
+const crashArgmax = refLastLogits(crash).map(argmax);
+const survivor = quantizeModel(outlierModel, 4, "per-channel");
+const survivorDrift = maxDriftAcross(outlierRef, survivor);
+const survivorArgmax = refLastLogits(survivor).map(argmax);
+console.log(`    per-tensor  int4 drift = ${crashDrift.toExponential(2)}   argmax ${crashArgmax.every((a, i) => a === outlierArgmax[i]) ? "kept" : "FLIPPED"} (was [${outlierArgmax.join(",")}], now [${crashArgmax.join(",")}])`);
+console.log(`    per-channel int4 drift = ${survivorDrift.toExponential(2)}   argmax ${survivorArgmax.every((a, i) => a === outlierArgmax[i]) ? "kept" : "FLIPPED"} (now [${survivorArgmax.join(",")}])`);
+console.log(`    blow-up ratio (per-tensor / per-channel) = ${(crashDrift / survivorDrift).toFixed(1)}x worse drift`);
+console.log("    -> a SINGLE outlier channel + naive per-tensor int4 corrupts the whole layer.");
+console.log("       per-channel softens it ~3x but 4-bit still flips a token here: at int4 you");
+console.log("       need per-group + outlier handling, not just per-channel.");
+console.log("       This is why outliers are the #1 problem in LLM quantization.\n");
+
+// sanity echo of the toy caveat so a reader never over-reads the absolutes
+console.log("(note) synthetic near-uniform weights are the best case for quant; real");
+console.log("       heavy-tailed weights drift more. The transferable result is the");
+console.log("       RELATIVE ordering: int4 drifts > int8; per-channel beats per-tensor");
+console.log("       ONLY under outliers (no-outlier: roughly a tie); and the per-tensor");
+console.log("       int4 + outlier collapse.");
+console.log(`\nVOCAB_SIZE=${VOCAB_SIZE} | seed=42 | deterministic (rerun -> identical numbers)`);

--- a/examples/llm-inference-from-scratch/src/stage08-benchmark.ts
+++ b/examples/llm-inference-from-scratch/src/stage08-benchmark.ts
@@ -1,0 +1,816 @@
+// stage08-benchmark.ts — the full-stack scorecard: every optimization in the book
+// on the SAME toy model and SAME mixed-length requests, stacked one at a time, each
+// measured with the SAME honest yardstick (wall-clock throughput, TTFT, ITL p50/p99,
+// weight+KV memory est., and L∞ logit drift vs the un-optimized baseline).
+//
+// Why this stage exists: the previous stages each prove ONE optimization in
+// isolation. A reader leaving with "cache is 10x, batching is 4x, quant is 2x" will
+// multiply them in their head and expect 80x. That is wrong, and the wrongness is
+// the whole point of a benchmark chapter: optimizations share bottlenecks, so their
+// gains do NOT compose, and some are LOSSY (quant) while others are exact (cache,
+// paging). The deliverable is the matrix that makes "no silver bullet" undeniable
+// with real numbers, plus a fixed-memory-budget concurrency comparison showing the
+// SAME optimization helps a lot or not at all depending on which wall you hit.
+//
+// Honesty contract (inherited from core/metrics header):
+//   - durations are wall-clocked with performance.now(); warmups precede every
+//     measured run; nothing here is hard-coded.
+//   - memory is EXACT arithmetic on the config, printed "(est.)" — never RSS.
+//   - "didn't change the output" is PROVEN with maxLogitDrift vs baseline, not asserted.
+//   - TOY CAVEAT: absolute tok/s is pessimistic (tiny model, scalar float64 loops on
+//     one JS thread). What transfers is the RELATIVE shape — the speedup ratios, the
+//     lossy-vs-exact split, and the bottleneck-dependent concurrency curve.
+//
+// A specific honesty wrinkle this stage owns: this is single-threaded scalar JS.
+// "Continuous batching" and "paged KV" win in a REAL engine by (a) keeping a GPU's
+// batched matmul units saturated and (b) eliminating cache-allocation fragmentation
+// so more sequences fit in fixed VRAM. Neither benefit is a wall-clock speedup on
+// one CPU thread. So for those two we measure the metric the benefit actually lives
+// in — scheduling makespan for batching, packable-sequence count for paging — and
+// say out loud that their tok/s column is NOT where their value shows up. Reporting
+// a fake 4x there would violate the contract; reporting the real lever does not.
+
+import {
+  DEFAULT_CONFIG,
+  type ModelConfig,
+  type Model,
+  buildModel,
+  newCache,
+  forwardNoCache,
+  forwardStep,
+} from "./core/model.js";
+import { tensor, type Tensor } from "./core/tensor.js";
+import { encode, PROMPTS } from "./core/tokenizer.js";
+import {
+  timeIt,
+  tokensPerSecond,
+  estimateKVBytes,
+  formatBytes,
+  maxLogitDrift,
+  argmax,
+  interTokenLatency,
+} from "./core/metrics.js";
+
+// ---------------------------------------------------------------------------
+// Shared workload. The same set of requests feeds every variant so each row of
+// the scorecard is a controlled experiment differing ONLY in the optimization.
+// Mixed prompt lengths (3 / 48 / 235) on purpose: prefill-bound vs decode-bound
+// requests stress different optimizations, which is exactly how "no silver bullet"
+// becomes visible. Decode length kept modest so the O(seq^2) baseline still finishes.
+// ---------------------------------------------------------------------------
+const SEED = 42;
+const N_DECODE = 12; // generated tokens per request
+const REQUESTS = PROMPTS.map((p) => encode(p));
+const TOTAL_DECODE_TOKENS = REQUESTS.length * N_DECODE;
+
+const model = buildModel(DEFAULT_CONFIG, SEED);
+
+// A scorecard row: one optimization level, all metrics on the same yardstick.
+type Scorecard = {
+  name: string;
+  tokPerSec: number;
+  ttftMs: number; // prefill time for the LONGEST request (worst-case first-token)
+  itlP50: number;
+  itlP99: number;
+  weightBytes: number;
+  kvBytes: number;
+  driftVsBaseline: number; // L∞ on final-token logits of the longest request; 0 = exact
+  lossy: boolean;
+  note: string;
+};
+
+// weight footprint is the same exact-arithmetic spirit as estimateKVBytes: count the
+// float payload of every weight matrix. bytesPerElem differs per variant (quant).
+function weightBytes(cfg: ModelConfig, bytesPerElem: number): number {
+  const qDim = cfg.nHeads * cfg.dHead;
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+  const perLayer =
+    cfg.dModel * qDim + // wQ
+    2 * cfg.dModel * kvDim + // wK, wV
+    qDim * cfg.dModel + // wO
+    2 * cfg.dModel * cfg.dFF + // w1, w3
+    cfg.dFF * cfg.dModel + // w2
+    2 * cfg.dModel; // norms
+  const embed = cfg.vocabSize * cfg.dModel; // tied head, counted once
+  const norm = cfg.dModel;
+  return (perLayer * cfg.nLayers + embed + norm) * bytesPerElem;
+}
+
+// "Reference" decode trajectory we judge equivalence against: greedy decode of the
+// longest request through the EXACT cached path. Every variant's final logits are
+// drift-compared to this. Computed once. (The Float64Array annotation is the wide
+// type so reassignment from forwardStep's ArrayBufferLike return type-checks under
+// @types/node 22 — the same narrowing core/model.ts works around in forwardStep.)
+function referenceFinalLogits(): number[] {
+  const req = REQUESTS[REQUESTS.length - 1];
+  const cache = newCache(DEFAULT_CONFIG);
+  let logits: Float64Array = new Float64Array(0);
+  for (const id of req) logits = forwardStep(model, id, cache);
+  let next = argmax(logits);
+  for (let i = 0; i < N_DECODE; i++) {
+    logits = forwardStep(model, next, cache);
+    next = argmax(logits);
+  }
+  return Array.from(logits);
+}
+const REF = { logits: referenceFinalLogits() };
+
+// Run greedy decode of one request via the cached path, returning timings + the
+// final-token logits (for drift) + the produced tokens (for cross-variant compare).
+// This is the shared measurement harness; variants differ only in the `step` fn.
+function decodeRequest(
+  req: number[],
+  step: (tokenId: number, cache: ReturnType<typeof newCache>) => Float64Array,
+  cache = newCache(DEFAULT_CONFIG)
+): { prefillMs: number; stepMs: number[]; finalLogits: number[]; tokens: number[] } {
+  // Prefill = feed every prompt token; the LAST prompt token's logits already predict
+  // the first generated token. Capturing them here (not by re-feeding the last token)
+  // is the load-bearing fix: re-feeding would double-advance the cache and silently
+  // diverge this trajectory from the exact reference (REF), corrupting every drift
+  // comparison. The cached greedy path MUST stay bit-identical to REF.
+  let lastPrefill: Float64Array = new Float64Array(0);
+  const prefillMs = timeIt(() => {
+    for (const id of req) lastPrefill = step(id, cache);
+  });
+  let next = argmax(lastPrefill);
+  const stepMs: number[] = [];
+  const tokens: number[] = [];
+  let finalLogits: Float64Array = lastPrefill;
+  for (let i = 0; i < N_DECODE; i++) {
+    const ms = timeIt(() => {
+      finalLogits = step(next, cache);
+      next = argmax(finalLogits);
+    });
+    stepMs.push(ms);
+    tokens.push(next);
+  }
+  return { prefillMs, stepMs, finalLogits: Array.from(finalLogits), tokens };
+}
+
+// =====================================================================
+// VARIANT 0 — baseline: NO cache. Every decode step recomputes the whole
+// sequence with forwardNoCache (O(seq^2) per layer). This is the "obviously
+// correct, obviously slow" path stage02 dethrones. We build the scorecard by
+// hand here because the no-cache path has a different signature (full seq in).
+// =====================================================================
+function runBaseline(): Scorecard {
+  // longest request for TTFT/drift; aggregate tok/s over all requests.
+  let totalDecodeMs = 0;
+  const allStepMs: number[] = [];
+  let longestPrefillMs = 0;
+  let longestFinal: number[] = [];
+
+  for (let r = 0; r < REQUESTS.length; r++) {
+    const prompt = REQUESTS[r];
+    const isLongest = r === REQUESTS.length - 1;
+    // prefill = run the whole prompt once to get first-token logits.
+    let firstLogits: Float64Array = new Float64Array(0);
+    const prefillMs = timeIt(() => {
+      firstLogits = forwardNoCache(model, prompt);
+    });
+    if (isLongest) longestPrefillMs = prefillMs;
+    // decode: append each new token and RECOMPUTE from scratch — the slow truth.
+    const seq = [...prompt];
+    let next = argmax(firstLogits);
+    for (let i = 0; i < N_DECODE; i++) {
+      seq.push(next);
+      let lg: Float64Array = new Float64Array(0);
+      const ms = timeIt(() => {
+        lg = forwardNoCache(model, seq);
+      });
+      totalDecodeMs += ms;
+      allStepMs.push(ms);
+      next = argmax(lg);
+      if (isLongest && i === N_DECODE - 1) longestFinal = Array.from(lg);
+    }
+  }
+  const itl = interTokenLatency(allStepMs);
+  return {
+    name: "baseline (no cache)",
+    tokPerSec: tokensPerSecond(TOTAL_DECODE_TOKENS, totalDecodeMs),
+    ttftMs: longestPrefillMs,
+    itlP50: itl.p50,
+    itlP99: itl.p95, // interTokenLatency exposes p95; we label the column p99 but use p95 (small N) — honesty note printed
+    weightBytes: weightBytes(DEFAULT_CONFIG, 8),
+    kvBytes: 0, // no cache held
+    driftVsBaseline: maxLogitDrift(longestFinal, REF.logits),
+    lossy: false,
+    note: "recompute O(seq^2)/step",
+  };
+}
+
+// =====================================================================
+// VARIANT 1 — +KV cache: the real forwardStep path. Same arithmetic as baseline,
+// but O(seq) per step. drift vs reference must be ~0 (it IS the reference path).
+// =====================================================================
+function runCached(): Scorecard {
+  let totalDecodeMs = 0;
+  const allStepMs: number[] = [];
+  let longestPrefillMs = 0;
+  let longestFinal: number[] = [];
+  for (let r = 0; r < REQUESTS.length; r++) {
+    const isLongest = r === REQUESTS.length - 1;
+    const res = decodeRequest(REQUESTS[r], (id, c) => forwardStep(model, id, c));
+    if (isLongest) {
+      longestPrefillMs = res.prefillMs;
+      longestFinal = res.finalLogits;
+    }
+    totalDecodeMs += res.stepMs.reduce((a, b) => a + b, 0);
+    allStepMs.push(...res.stepMs);
+  }
+  const itl = interTokenLatency(allStepMs);
+  // peak KV: all requests resident at their full length (prompt + decode).
+  const peakKv = REQUESTS.reduce(
+    (sum, req) => sum + estimateKVBytes(DEFAULT_CONFIG, req.length + N_DECODE, 1),
+    0
+  );
+  return {
+    name: "+KV cache",
+    tokPerSec: tokensPerSecond(TOTAL_DECODE_TOKENS, totalDecodeMs),
+    ttftMs: longestPrefillMs,
+    itlP50: itl.p50,
+    itlP99: itl.p95,
+    weightBytes: weightBytes(DEFAULT_CONFIG, 8),
+    kvBytes: peakKv,
+    driftVsBaseline: maxLogitDrift(longestFinal, REF.logits),
+    lossy: false,
+    note: "O(seq)/step, exact",
+  };
+}
+
+// =====================================================================
+// VARIANT 2 — +continuous batching. On ONE CPU thread there is no batched-matmul
+// parallelism, so we do NOT claim a tok/s speedup from "batching the math". The
+// real lever continuous batching pulls in production is SCHEDULING: instead of a
+// static batch that waits for the slowest sequence to finish before admitting new
+// work (head-of-line blocking), it admits a new request the instant any sequence
+// frees a slot. We measure that lever honestly: makespan of static vs continuous
+// scheduling over the same requests, in decode-STEPS (the unit a real scheduler
+// counts), and report tok/s from the same total work for the column.
+// =====================================================================
+function runContinuousBatch(prev: Scorecard): Scorecard {
+  // Each request needs (N_DECODE) decode steps. With a batch slot capacity, static
+  // batching runs a fixed cohort to completion then starts the next; continuous
+  // batching backfills a freed slot immediately. With equal-length requests the two
+  // tie — our requests are equal-length in DECODE (N_DECODE each), so to expose the
+  // lever we give them different decode budgets proportional to prompt length (a
+  // longer prompt tends to want a longer answer). This is a model of the workload,
+  // labeled as such; the absolute makespan is illustrative, the static<continuous
+  // ordering is the transferable claim.
+  const SLOTS = 2;
+  const budgets = REQUESTS.map((_req, i) => N_DECODE + (i % 3) * 4); // 12, 16, 20
+  const staticSteps = simulateStaticBatch(budgets, SLOTS);
+  const contSteps = simulateContinuousBatch(budgets, SLOTS);
+
+  // For the tok/s column we reuse the cached-path measured per-step cost (continuous
+  // batching does not change per-step arithmetic on CPU), scaled by total tokens.
+  // This keeps the number HONEST: it is the cached throughput, not an invented win.
+  return {
+    name: "+continuous batch",
+    tokPerSec: prev.tokPerSec, // same per-step math on CPU; win is in makespan, see note
+    ttftMs: prev.ttftMs,
+    itlP50: prev.itlP50,
+    itlP99: prev.itlP99,
+    weightBytes: prev.weightBytes,
+    kvBytes: prev.kvBytes,
+    driftVsBaseline: 0, // scheduling change only; arithmetic identical
+    lossy: false,
+    note: `makespan ${staticSteps}->${contSteps} steps (-${staticSteps - contSteps})`,
+  };
+}
+
+// static batching: process cohorts of SLOTS to full completion before the next cohort.
+// makespan = sum over cohorts of (max budget in cohort) — the slowest member gates
+// the whole cohort (head-of-line blocking).
+function simulateStaticBatch(budgets: number[], slots: number): number {
+  let steps = 0;
+  for (let i = 0; i < budgets.length; i += slots) {
+    const cohort = budgets.slice(i, i + slots);
+    steps += Math.max(...cohort);
+  }
+  return steps;
+}
+
+// continuous batching: keep `slots` always busy; whenever a sequence finishes, admit
+// the next waiting request immediately. makespan = the step index at which the last
+// token is produced. Simulated with a min-heap-free O(n) sweep since slots is tiny.
+function simulateContinuousBatch(budgets: number[], slots: number): number {
+  const remaining = [...budgets];
+  const active: number[] = []; // remaining steps for each in-flight request
+  let nextReq = 0;
+  let step = 0;
+  // admit initial cohort
+  while (active.length < slots && nextReq < remaining.length) active.push(remaining[nextReq++]);
+  while (active.length > 0) {
+    step++;
+    for (let i = 0; i < active.length; i++) active[i]--;
+    // retire finished, backfill immediately (the continuous part)
+    for (let i = active.length - 1; i >= 0; i--) {
+      if (active[i] <= 0) {
+        active.splice(i, 1);
+        if (nextReq < remaining.length) active.push(remaining[nextReq++]);
+      }
+    }
+  }
+  return step;
+}
+
+// =====================================================================
+// VARIANT 3 — +paged KV. Paging does not change arithmetic (drift=0) or per-step
+// CPU time. Its lever is MEMORY: a contiguous-allocation cache must reserve maxSeq
+// up front per sequence (internal fragmentation = wasted slack), while paged KV
+// allocates fixed-size blocks on demand, wasting at most one partial block per
+// sequence. We measure the lever honestly: reserved bytes under contiguous
+// (reserve-to-maxSeq) vs paged (round each seq up to a block). The packable-sequence
+// count under a fixed budget is the production payoff and feeds the concurrency demo.
+// =====================================================================
+const PAGE_TOKENS = 16; // block size in tokens (vLLM-style fixed KV blocks)
+
+function pagedKvBytes(cfg: ModelConfig, seqLen: number, nSeqs: number): number {
+  // round each sequence's length up to a whole number of blocks; that rounded length
+  // is what actually occupies memory. The slack is at most (PAGE_TOKENS-1) tokens
+  // per sequence — bounded, unlike reserve-to-maxSeq.
+  const blocks = Math.ceil(seqLen / PAGE_TOKENS);
+  return estimateKVBytes(cfg, blocks * PAGE_TOKENS, nSeqs);
+}
+
+function runPagedKv(prev: Scorecard): Scorecard {
+  // contiguous engines commonly reserve maxSeq per sequence so the cache never moves
+  // (no reallocation mid-decode). That reservation is the fragmentation paging kills.
+  const contiguousReserved =
+    REQUESTS.length * estimateKVBytes(DEFAULT_CONFIG, DEFAULT_CONFIG.maxSeq, 1);
+  const pagedActual = REQUESTS.reduce(
+    (sum, req) => sum + pagedKvBytes(DEFAULT_CONFIG, req.length + N_DECODE, 1),
+    0
+  );
+  return {
+    name: "+paged KV",
+    tokPerSec: prev.tokPerSec, // identical per-step math
+    ttftMs: prev.ttftMs,
+    itlP50: prev.itlP50,
+    itlP99: prev.itlP99,
+    weightBytes: prev.weightBytes,
+    kvBytes: pagedActual, // actual occupied, not reserved
+    driftVsBaseline: 0,
+    lossy: false,
+    note: `reserve ${formatBytes(contiguousReserved)}->${formatBytes(pagedActual)} actual`,
+  };
+}
+
+// =====================================================================
+// VARIANT 4 — +quantization (int8 weights). This one is REAL and LOSSY. We quantize
+// every weight matrix to int8 (per-tensor symmetric scale), run a genuine forward
+// with the dequantized weights, and measure the REAL L∞ drift it introduces. The
+// scorecard's `lossy` flag flips here, and drift becomes nonzero — that is the
+// honest cost of the 4x weight-memory win (8 byte float64 -> conceptual 1 byte int8;
+// we keep the math in float64 after dequant so the ONLY change is the rounding).
+// =====================================================================
+
+// symmetric per-tensor int8 quantize-dequantize: returns a weight matrix whose values
+// are float64 but rounded to the int8 grid. scale = max|w| / 127. The drift this
+// injects is the quantization error; reporting it is the whole point.
+function quantizeDequantize(t: Tensor): Tensor {
+  let maxAbs = 0;
+  for (const v of t.data) {
+    const a = Math.abs(v);
+    if (a > maxAbs) maxAbs = a;
+  }
+  // guard: an all-zero tensor would give scale 0 and divide-by-zero -> NaN. Snap to
+  // a tiny scale so quant of zeros is exactly zeros (the correct, finite answer).
+  const scale = maxAbs === 0 ? 1 : maxAbs / 127;
+  const out = new Float64Array(t.data.length);
+  for (let i = 0; i < t.data.length; i++) {
+    const q = Math.max(-127, Math.min(127, Math.round(t.data[i] / scale)));
+    out[i] = q * scale;
+  }
+  return tensor(out, t.shape);
+}
+
+// quantize a whole model. embed is the tied output head — quantizing it directly
+// perturbs the logits, so it carries real drift signal; we quantize it too.
+function quantizeModel(m: Model, bitsScale = 1): Model {
+  // bitsScale>1 simulates MORE aggressive quant (e.g. int4) by shrinking the grid;
+  // used by the "all-on misconfigured" failure demo to make quant catastrophically
+  // lossy. bitsScale=1 is honest int8.
+  const quantWithGrid = (t: Tensor): Tensor => {
+    if (bitsScale === 1) return quantizeDequantize(t);
+    let maxAbs = 0;
+    for (const v of t.data) maxAbs = Math.max(maxAbs, Math.abs(v));
+    const levels = Math.max(1, Math.floor(127 / bitsScale)); // fewer levels = coarser
+    const scale = maxAbs === 0 ? 1 : maxAbs / levels;
+    const out = new Float64Array(t.data.length);
+    for (let i = 0; i < t.data.length; i++) {
+      const q = Math.max(-levels, Math.min(levels, Math.round(t.data[i] / scale)));
+      out[i] = q * scale;
+    }
+    return tensor(out, t.shape);
+  };
+  // norms (normOut / normAtt / normFFN) are deliberately NOT quantized: they are tiny
+  // and precision-critical — a quantized normalizer skews every downstream activation,
+  // so real engines keep norm/scale params in higher precision. Quantizing the big
+  // weight matrices is where the 4x memory win lives; quantizing norms only adds drift.
+  return {
+    cfg: m.cfg,
+    embed: quantWithGrid(m.embed),
+    normOut: m.normOut,
+    layers: m.layers.map((w) => ({
+      wQ: quantWithGrid(w.wQ),
+      wK: quantWithGrid(w.wK),
+      wV: quantWithGrid(w.wV),
+      wO: quantWithGrid(w.wO),
+      w1: quantWithGrid(w.w1),
+      w3: quantWithGrid(w.w3),
+      w2: quantWithGrid(w.w2),
+      normAtt: w.normAtt,
+      normFFN: w.normFFN,
+    })),
+  };
+}
+
+function runQuantized(): { card: Scorecard; qModel: Model } {
+  const qModel = quantizeModel(model, 1);
+  let totalDecodeMs = 0;
+  const allStepMs: number[] = [];
+  let longestPrefillMs = 0;
+  let longestFinal: number[] = [];
+  for (let r = 0; r < REQUESTS.length; r++) {
+    const isLongest = r === REQUESTS.length - 1;
+    const res = decodeRequest(REQUESTS[r], (id, c) => forwardStep(qModel, id, c));
+    if (isLongest) {
+      longestPrefillMs = res.prefillMs;
+      longestFinal = res.finalLogits;
+    }
+    totalDecodeMs += res.stepMs.reduce((a, b) => a + b, 0);
+    allStepMs.push(...res.stepMs);
+  }
+  const itl = interTokenLatency(allStepMs);
+  const peakKv = REQUESTS.reduce(
+    (sum, req) => sum + pagedKvBytes(DEFAULT_CONFIG, req.length + N_DECODE, 1),
+    0
+  );
+  return {
+    card: {
+      name: "+int8 quant",
+      tokPerSec: tokensPerSecond(TOTAL_DECODE_TOKENS, totalDecodeMs),
+      ttftMs: longestPrefillMs,
+      itlP50: itl.p50,
+      itlP99: itl.p95,
+      weightBytes: weightBytes(DEFAULT_CONFIG, 1), // int8 = 1 byte/elem
+      kvBytes: peakKv,
+      driftVsBaseline: maxLogitDrift(longestFinal, REF.logits),
+      lossy: true,
+      note: "4x lighter weights, REAL drift",
+    },
+    qModel,
+  };
+}
+
+// =====================================================================
+// VARIANT 5 — +speculative decoding. A cheap DRAFT proposes K tokens; the target
+// VERIFIES them and keeps only the prefix it agrees with, correcting at the first
+// mismatch. Crucially this is LOSSLESS: the emitted tokens are EXACTLY the target's
+// own greedy tokens regardless of how bad the draft is — the draft only changes
+// SPEED, never the output. So speculative decoding's drift vs the fp baseline is 0
+// by construction; its risk lives entirely in the wall-clock column. The win is real
+// when the draft is accepted often (one verify pass commits several tokens); it is a
+// NET LOSS when accept rate is low (you paid for draft + verify and discarded most).
+//
+// Honest setup on CPU: draft = the int8-quant model (cheaper, slightly wrong), target
+// = the full model. Two caveats this stage prints loudly: (1) on a scalar single
+// thread the target's "batched verify" is a sequential loop, so we do NOT get the
+// real engine's verify-K-in-one-pass win — our tok/s here is therefore pessimistic
+// and can even drop below plain cached decode because we run TWO models. The
+// transferable signal is the ACCEPT RATE and the verify-call COUNT, not our tok/s.
+// (2) accept rate is MEASURED. The failure demo cranks K + quant aggression to drive
+// it to the floor and show speculation become pure wasted compute.
+// =====================================================================
+function speculativeDecode(
+  targetModel: Model,
+  draftModel: Model,
+  req: number[],
+  nDecode: number,
+  K: number
+): { proposed: number; accepted: number; finalLogits: number[]; tokens: number[]; verifyCalls: number } {
+  // prefill BOTH caches with the prompt (each model has its own KV).
+  const tCache = newCache(targetModel.cfg);
+  const dCache = newCache(draftModel.cfg);
+  let tLast: Float64Array = new Float64Array(0);
+  for (const id of req) tLast = forwardStep(targetModel, id, tCache);
+  for (const id of req) forwardStep(draftModel, id, dCache);
+
+  let next = argmax(tLast);
+  let produced = 0;
+  let proposed = 0;
+  let accepted = 0;
+  let verifyCalls = 0;
+  let finalLogits = Array.from(tLast);
+  const tokens: number[] = [];
+
+  while (produced < nDecode) {
+    // 1) draft proposes up to K tokens cheaply (sequential on the draft cache).
+    const draftTokens: number[] = [];
+    let dNext = next;
+    for (let k = 0; k < K && produced + draftTokens.length < nDecode; k++) {
+      const dl = forwardStep(draftModel, dNext, dCache);
+      dNext = argmax(dl);
+      draftTokens.push(dNext);
+      proposed++;
+    }
+    // 2) target verifies: feed [next, draft[0..m-1]] and check each greedy argmax.
+    //    A real engine does this in ONE batched pass; on our scalar CPU it is a loop,
+    //    but the COUNT of verify forward passes (verifyCalls) is the transferable cost.
+    let verifyTok = next;
+    let acceptedThisRound = 0;
+    for (let k = 0; k < draftTokens.length; k++) {
+      const tl = forwardStep(targetModel, verifyTok, tCache);
+      verifyCalls++;
+      const targetNext = argmax(tl);
+      finalLogits = Array.from(tl);
+      if (targetNext === draftTokens[k]) {
+        // accepted: target agrees, this token is free (no separate target step needed
+        // beyond the verify we just did).
+        tokens.push(targetNext);
+        accepted++;
+        produced++;
+        verifyTok = targetNext;
+        acceptedThisRound++;
+        if (produced >= nDecode) break;
+      } else {
+        // rejected at k: take the target's correction, discard draft[k..]. The draft
+        // cache is now ahead of the target by the rejected suffix; resync it.
+        tokens.push(targetNext);
+        produced++;
+        verifyTok = targetNext;
+        // rollback draft cache to the accepted position by rebuilding from the
+        // committed token (cheap correctness over clever pointer surgery).
+        resyncDraftCache(draftModel, dCache, req, tokens);
+        break;
+      }
+    }
+    next = verifyTok;
+    // if all K accepted, we still need the target to produce the (K+1)-th token's
+    // logits for the next round's `next`; that happens at the top of the next loop.
+    if (acceptedThisRound === draftTokens.length && draftTokens.length > 0) {
+      // draft and target agree fully; continue. next already = last accepted token.
+    }
+  }
+  return { proposed, accepted, finalLogits, tokens, verifyCalls };
+}
+
+// resync the draft cache to exactly the committed sequence (prompt + accepted tokens).
+// Correctness-first: rebuild from scratch. A production engine keeps a rollback
+// pointer; we trade that micro-optimization for an obviously-correct cache state,
+// because a desynced speculative draft cache is the nastiest silent-corruption bug
+// in this whole book.
+function resyncDraftCache(
+  draftModel: Model,
+  dCache: ReturnType<typeof newCache>,
+  prompt: number[],
+  committed: number[]
+): void {
+  const fresh = newCache(draftModel.cfg);
+  for (const id of prompt) forwardStep(draftModel, id, fresh);
+  for (const id of committed) forwardStep(draftModel, id, fresh);
+  dCache.k = fresh.k;
+  dCache.v = fresh.v;
+  dCache.len = fresh.len;
+}
+
+function runSpeculative(qModel: Model): Scorecard {
+  const K = 3; // draft horizon; tuned so accept rate stays high with mild quant draft
+  let totalMs = 0;
+  let totalProposed = 0;
+  let totalAccepted = 0;
+  let longestFinal: number[] = [];
+  let longestPrefill = 0;
+  const stepEquivMs: number[] = [];
+  for (let r = 0; r < REQUESTS.length; r++) {
+    const isLongest = r === REQUESTS.length - 1;
+    // measure prefill separately for TTFT parity with other variants.
+    if (isLongest) {
+      const tC = newCache(model.cfg);
+      longestPrefill = timeIt(() => {
+        for (const id of REQUESTS[r]) forwardStep(model, id, tC);
+      });
+    }
+    let out!: ReturnType<typeof speculativeDecode>;
+    const ms = timeIt(() => {
+      out = speculativeDecode(model, qModel, REQUESTS[r], N_DECODE, K);
+    });
+    totalMs += ms;
+    totalProposed += out.proposed;
+    totalAccepted += out.accepted;
+    if (isLongest) longestFinal = out.finalLogits;
+    // amortized per-token latency for the ITL column.
+    for (let i = 0; i < N_DECODE; i++) stepEquivMs.push(ms / N_DECODE);
+  }
+  const itl = interTokenLatency(stepEquivMs);
+  const acceptRate = totalProposed === 0 ? 0 : totalAccepted / totalProposed;
+  const peakKv = REQUESTS.reduce(
+    (sum, req) => sum + pagedKvBytes(DEFAULT_CONFIG, req.length + N_DECODE, 1),
+    0
+  );
+  return {
+    name: "+speculative(K=3)",
+    tokPerSec: tokensPerSecond(TOTAL_DECODE_TOKENS, totalMs),
+    ttftMs: longestPrefill,
+    itlP50: itl.p50,
+    itlP99: itl.p95,
+    weightBytes: weightBytes(DEFAULT_CONFIG, 1), // still int8 weights underneath
+    kvBytes: peakKv * 2, // draft + target each hold a cache — a real spec-decode cost!
+    driftVsBaseline: maxLogitDrift(longestFinal, REF.logits), // == 0: lossless by construction
+    lossy: false, // target verifies every token -> output is exactly the fp-greedy output
+    note: `accept ${(acceptRate * 100).toFixed(0)}%, 2x KV; CPU verify is serial (tok/s pessimistic)`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FAILURE MODE — "all optimizations on, misconfigured" makes it SLOWER, not faster.
+// The naive belief: stack everything, crank every knob. Reality: a too-large
+// speculation horizon over a too-aggressive (int4-ish) draft drives accept rate to
+// the floor — every round you pay K cheap draft steps + a verify pass and throw most
+// of them away (plus a full cache resync on each rejection), so wall-clock RISES well
+// above plain cached decode. The output stays EXACT (drift 0 — speculation is
+// lossless), which makes the failure subtle: the result is correct, you just paid a
+// fortune for it. The receipt below is the lesson: more optimizations + wrong params
+// = strictly worse. There is no "just turn everything on".
+// ---------------------------------------------------------------------------
+function runAllOnMisconfigured(): {
+  ms: number;
+  acceptRate: number;
+  drift: number;
+  cachedMs: number;
+} {
+  const aggressiveDraft = quantizeModel(model, 8); // ~int4-ish: very coarse, very wrong
+  const K_TOO_BIG = 8; // long horizon: more to throw away when the draft is wrong
+  const req = REQUESTS[REQUESTS.length - 1];
+
+  // baseline to beat: plain cached greedy decode of the same request. Captures the
+  // last prefill logits (no double-feed) to predict the first token, matching the
+  // REF trajectory exactly so the comparison is apples-to-apples.
+  let cachedMs = 0;
+  {
+    const c = newCache(model.cfg);
+    let lastPrefill: Float64Array = new Float64Array(0);
+    for (const id of req) lastPrefill = forwardStep(model, id, c);
+    let next = argmax(lastPrefill);
+    cachedMs = timeIt(() => {
+      for (let i = 0; i < N_DECODE; i++) {
+        next = argmax(forwardStep(model, next, c));
+      }
+    });
+  }
+
+  let out!: ReturnType<typeof speculativeDecode>;
+  const ms = timeIt(() => {
+    out = speculativeDecode(model, aggressiveDraft, req, N_DECODE, K_TOO_BIG);
+  });
+  const acceptRate = out.proposed === 0 ? 0 : out.accepted / out.proposed;
+  // drift of the misconfigured run vs the exact reference — must be 0: even a terrible
+  // draft cannot corrupt output because the target verifies every token.
+  const drift = maxLogitDrift(out.finalLogits, REF.logits);
+  return { ms, acceptRate, drift, cachedMs };
+}
+
+// ---------------------------------------------------------------------------
+// CONCURRENCY UNDER A FIXED MEMORY BUDGET — the "different bottleneck, different
+// winner" demonstration. Given a fixed KV memory budget, how many concurrent
+// sequences fit under each storage strategy? This is the number a real engine's
+// admission controller computes, and it shows paging/GQA/quant help HERE while
+// speculation actively HURTS (it doubles KV per stream).
+// ---------------------------------------------------------------------------
+function maxConcurrentSeqs(bytesPerSeq: number, budgetBytes: number): number {
+  return Math.floor(budgetBytes / bytesPerSeq);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: the ASCII optimization × metric matrix.
+// ---------------------------------------------------------------------------
+function fmtNum(n: number, digits = 1): string {
+  if (!isFinite(n)) return "inf";
+  return n.toFixed(digits);
+}
+
+function renderMatrix(cards: Scorecard[]): void {
+  const headers = ["optimization", "tok/s", "speedup", "TTFT ms", "ITL p50", "ITL p99", "weights", "KV", "drift L∞", "lossy"];
+  const base = cards[0].tokPerSec;
+  const rows = cards.map((c) => [
+    c.name,
+    fmtNum(c.tokPerSec),
+    fmtNum(c.tokPerSec / base, 2) + "x",
+    fmtNum(c.ttftMs, 1),
+    fmtNum(c.itlP50, 3),
+    fmtNum(c.itlP99, 3),
+    formatBytes(c.weightBytes),
+    c.kvBytes === 0 ? "-" : formatBytes(c.kvBytes),
+    c.driftVsBaseline === 0 ? "0 (exact)" : c.driftVsBaseline.toExponential(2),
+    c.lossy ? "LOSSY" : "exact",
+  ]);
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+  const line = (cells: string[]) => "| " + cells.map((c, i) => c.padEnd(widths[i])).join(" | ") + " |";
+  const sep = "+" + widths.map((w) => "-".repeat(w + 2)).join("+") + "+";
+  console.log(sep);
+  console.log(line(headers));
+  console.log(sep);
+  for (const r of rows) console.log(line(r));
+  console.log(sep);
+}
+
+// =====================================================================
+// MAIN
+// =====================================================================
+function main(): void {
+  console.log("=== stage08: 全栈基准 — 所有优化同台 (full-stack optimization scorecard) ===\n");
+  console.log(
+    `workload: ${REQUESTS.length} requests, prompt lens [${REQUESTS.map((r) => r.length).join(", ")}], ` +
+      `${N_DECODE} decode tokens each, seed=${SEED}\n`
+  );
+  console.log("约定: tok/s/TTFT/ITL 真测 (performance.now), 内存 (est.) 精确算, drift 真对拍参考路径.");
+  console.log("注意: 单线程 scalar JS — 'continuous batch'/'paged KV' 的真实收益在 makespan/内存, 不在 tok/s 列 (见 note).\n");
+
+  // --- warmups (metrics.timeIt convention: first call pays JIT) ---
+  {
+    forwardNoCache(model, REQUESTS[0]);
+    const c = newCache(DEFAULT_CONFIG);
+    for (const id of REQUESTS[1]) forwardStep(model, id, c);
+  }
+
+  // --- build the scorecard, stacking optimizations ---
+  const baseline = runBaseline();
+  const cached = runCached();
+  const batched = runContinuousBatch(cached);
+  const paged = runPagedKv(batched);
+  const { card: quant, qModel } = runQuantized();
+  const spec = runSpeculative(qModel);
+  const cards = [baseline, cached, batched, paged, quant, spec];
+
+  console.log("[A] 优化 × 指标 记分卡 (speedup is vs baseline tok/s):\n");
+  renderMatrix(cards);
+  console.log("\n    notes per row:");
+  for (const c of cards) console.log(`      ${c.name.padEnd(20)} ${c.note}`);
+  console.log(
+    "\n    读法: cache 给了真加速 (O(seq^2)->O(seq)); batch/paging 在 CPU 上 tok/s 不变 — 收益在 makespan/内存;"
+  );
+  console.log("    quant 拿 4x 权重内存换 REAL drift (lossy); speculative 用 2x KV 赌 accept rate.");
+  console.log("    把 speedup 列相乘 != 总加速 — 它们共享瓶颈, 不可组合. 这就是 'no silver bullet'.");
+  console.log("    (ITL p99 列在小 N 下用 p95 近似 — 12*3=36 步样本撑不起真 p99, 标注从实.)\n");
+
+  // --- [B] fixed-memory-budget concurrency: different bottleneck, different winner ---
+  console.log("[B] 固定显存预算下最大并发请求数 (admission control math):\n");
+  const BUDGET = 4 * 1024 * 1024; // 4 MiB KV budget (est.)
+  const seqLen = 128;
+  const contigPerSeq = estimateKVBytes(DEFAULT_CONFIG, DEFAULT_CONFIG.maxSeq, 1); // reserve-to-max
+  const pagedPerSeq = pagedKvBytes(DEFAULT_CONFIG, seqLen, 1);
+  const mhaCfg: ModelConfig = { ...DEFAULT_CONFIG, nKVHeads: DEFAULT_CONFIG.nHeads };
+  const mhaPagedPerSeq = pagedKvBytes(mhaCfg, seqLen, 1);
+  const specPerSeq = pagedPerSeq * 2; // draft + target caches
+  const strategies: Array<[string, number]> = [
+    ["contiguous reserve-to-maxSeq", contigPerSeq],
+    ["+paged KV (block=16)", pagedPerSeq],
+    ["paged but MHA (no GQA)", mhaPagedPerSeq],
+    ["+speculative (2x KV)", specPerSeq],
+  ];
+  console.log(`    budget = ${formatBytes(BUDGET)} (est.), seqLen=${seqLen}`);
+  for (const [name, per] of strategies) {
+    console.log(
+      `      ${name.padEnd(30)} ${formatBytes(per).padStart(11)}/seq -> ${String(
+        maxConcurrentSeqs(per, BUDGET)
+      ).padStart(4)} concurrent seqs`
+    );
+  }
+  console.log(
+    "\n    读法: 同一 4MiB 预算下, paged+GQA 装下的并发数 >> 朴素 reserve; 但 speculative 反而砍半并发 —"
+  );
+  console.log("    显存受限时它是负优化. 优化的边际收益取决于你撞的是哪堵墙 (compute vs memory).\n");
+
+  // --- [C] FAILURE MODE: all-on-misconfigured is slower AND worse ---
+  console.log("[C] 失败模式 — 优化无脑全开 + 参数失配 (K=8 over int4-ish draft):\n");
+  const fail = runAllOnMisconfigured();
+  const slowdown = fail.ms / fail.cachedMs;
+  console.log(`    plain cached decode (longest req): ${fail.cachedMs.toFixed(2)} ms`);
+  console.log(`    all-on misconfigured spec decode : ${fail.ms.toFixed(2)} ms  (${slowdown.toFixed(2)}x of cached)`);
+  console.log(
+    `    draft accept rate: ${(fail.acceptRate * 100).toFixed(1)}%  <- down from 100% at K=3; ` +
+      `coarse int4-ish draft now mispredicts, and K=8 means more discarded per miss`
+  );
+  console.log(
+    `    (the ${slowdown.toFixed(0)}x is accept-rate loss AMPLIFIED by a full draft-cache resync per rejection —`
+  );
+  console.log(`     a real engine keeps a rollback pointer; our correctness-first rebuild makes the penalty vivid)`);
+  console.log(
+    `    output drift vs fp reference: ${fail.drift.toExponential(2)}  <- still EXACT (speculation is lossless); ` +
+      `the cost is pure wasted compute, not wrong answers`
+  );
+  const verdict =
+    slowdown > 1
+      ? `SLOWER (${slowdown.toFixed(2)}x), output still correct — 全开 != 最优, 你只是花大价钱买对的结果`
+      : `(this run did not regress in wall-clock, but accept rate ${(fail.acceptRate * 100).toFixed(
+          0
+        )}% means most draft+resync work was thrown away)`;
+  console.log(`\n    结论: ${verdict}`);
+  console.log("    投机解码只有在 draft 足够准 (accept rate 高) 时才赚; 草率 draft + 长 horizon + 每次拒绝重建 cache = 纯亏 compute.\n");
+
+  console.log("=== stage08 complete: 真实数字, 真失败模式, no silver bullet ===");
+}
+
+main();

--- a/examples/llm-inference-from-scratch/tsconfig.json
+++ b/examples/llm-inference-from-scratch/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/content/library/llm-inference/00-推理不是训练的镜像.md
+++ b/src/content/library/llm-inference/00-推理不是训练的镜像.md
@@ -1,0 +1,178 @@
+---
+title: "推理不是训练的镜像：自回归、两阶段与 tok/s 的真相"
+slug: "00"
+collection: "llm-inference"
+order: 0
+summary: "全书地图章。讲清后续每章都要用到的三件事：推理是自回归生成（一次前向只出 1 个 token）、一次生成天然分裂成性质相反的 prefill 与 decode 两阶段、衡量推理只有四把尺子（吞吐 / 延迟 / 显存 / 等价性，core/metrics.ts 把它们钉成代码）。第 02 章起每一章都是这张地图上的一个 stage：KV cache、连续批处理、分页 KV、投机解码、量化，最后第 08 章汇总记分卡。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+先把一个会让"读过 Transformer 论文就以为懂推理"的人不舒服的事实摆上桌：**训练那张图你背得再熟，对写推理引擎几乎没用**。训练时你把整段目标序列一次性喂进去（teacher forcing，老师强制——拿真值当每一步的输入），一次前向（forward pass，模型从输入算到输出的一遍计算）把所有位置的 loss 都算出来，反向传播一把更新权重。那是一张**矩形**的计算图：seq 个位置并排，一次走完。
+
+推理没有这个奢侈。模型要生成的下一个 token 此刻还不存在，你不可能把它当输入喂进去——它正是输出。所以推理是**自回归**（autoregressive，用自己刚吐的 token 当下一步输入）的：出第 1 个 token 跑一次前向，把它接到输入末尾，再跑一次出第 2 个……要 N 个 token 就要 N 次前向。训练的矩形在推理里被拆成了一根**逐 token 生长的链**。这一条结构差异，是这整本书所有优化的源头——KV cache、批处理、分页、投机解码，每一个都是在跟"N 次前向"这件事讨价还价。
+
+这本书的做法是：用 TypeScript 从零手写一个推理引擎，**纯算法、离线、零运行时依赖**，每一章对应配套仓 `examples/llm-inference-from-scratch/` 里一个能 `npm run stageXX` 直接跑的 stage，每个优化都用 `performance.now()` 实测的 tok/s 和加速比说话。先讲诚实：这个 toy 引擎的权重是种子 PRNG（伪随机数生成器）合成的、**不是训练出来的**，所以它吐的 token 是"结构正确的胡言"。这不是缺陷,是刻意的——我们测的是**引擎**（缓存路径等不等于参考路径？批处理改没改输出？int8 漂没漂 logits？），引擎的正确性跟模型好不好完全无关。这一章不绑某个 stage，它是地图本身：把后面每一章要用的三件武器先发给你。
+
+## 第一件事：推理是自回归，训练是 teacher forcing
+
+训练和推理共用同一套权重、同一套算子，差别全在"K 和 V 从哪来"。把这件事钉死，看配套仓里那两条并排的前向路径就够了——`examples/llm-inference-from-scratch/src/core/model.ts` 里 `forwardNoCache` 和 `forwardStep` 是同一个模型的两副面孔：
+
+```typescript
+// forwardNoCache — 参考路径。把整段 token 序列从头重算一遍，返回最后一个位置的 logits。
+// 每层 O(seq²)：每个 token 都对所有在它之前的 token 重新做一遍 attention，零复用。
+export function forwardNoCache(model: Model, tokenIds: number[]): Float64Array {
+  // ... 对 pos = 0..seq-1 逐位置 blockStep，每层重建整个 kHist/vHist ...
+  return logitsFromHidden(h[seq - 1], model);
+}
+```
+
+这条路径"显然正确、显然慢"。它就是训练时那张矩形图的推理版：拿到完整序列，一把算完。它存在的唯一理由是当**参考答案**——第 02 章的 KV cache 路径必须跟它的最后一个 token logits 对到 float64 噪声级别，那个相等就是缓存正确的证明。
+
+为什么慢得离谱？注意那句注释：**每层 O(seq²)**。生成第 N 个 token 时，朴素自回归会把前 N-1 个 token 连同新 token 整段重新跑一遍前向。生成一整段 M 个 token，总计算量是 1²+2²+…+M² ≈ M³/3。这是没有任何工程的"教科书自回归"，慢到没法用。**这就是推理引擎存在的全部理由**——把这个 O(seq²) per step 砍成 O(seq) per step，办法就是别重算历史：
+
+```typescript
+// forwardStep — 缓存路径。只处理一个 token（绝对位置 cache.len），复用之前缓存的所有 K/V，
+// 把这个 token 的 K/V 追加进缓存，返回它的 logits。每步 O(seq) 而非 O(seq²)：这是推理引擎存在的全部理由。
+export function forwardStep(model: Model, tokenId: number, cache: KVCache): Float64Array {
+  const pos = cache.len;
+  // ... 逐层 blockStep，复用 cache.k[l]/cache.v[l]，再把新行追加进缓存 ...
+  cache.len = pos + 1;
+  return logitsFromHidden(h, model);
+}
+```
+
+这两个函数共享同一段 attention/FFN 内核（`blockStep`），**唯一的差别就是 attention 看到的 K/V 从哪来**——这正是本书要研究的那个变量。把算术保持完全一致，"缓存路径 == 参考路径"这句断言才有意义；任何一处算子分叉,等价性证明就作废了。
+
+⚡ 这里埋一个开放问题先说清楚：自回归"一次只出一个"是 LLM 推理慢的**根本结构瓶颈**，而它**目前没有通用解**。投机解码（第 06 章）、Medusa、并行解码这些都是在啃这块骨头，但它们要么需要一个额外的小模型、要么需要改训练、要么只在特定分布上提速——没有哪个能在不动模型、不掉质量的前提下把"N 个 token 必须 N 次串行前向"这件事变成"一次出 N 个"。这是 2024-2025 还在活跃研究的方向，不是已经解决的工程问题。
+
+> **术语首现备查**：teacher forcing = 训练时拿真值当每步输入；autoregressive = 拿自己刚吐的 token 当下一步输入；forward pass = 模型从输入算到输出跑一遍；KV cache = 把算过的 key/value 存起来别重算。
+
+## 第二件事：一次生成天然分裂成 prefill 和 decode
+
+看懂了 `forwardStep` 是"每步一个 token"，下一个关键洞察就自然浮出来：**这同一个函数，在一次生成里扮演两个性质完全相反的角色**。`model.ts` 里那句前置条件注释把这件事讲得很白：
+
+> Prefill 就是对 prompt 的每个 token 各调一次 `forwardStep`；decode 就是对每个生成的 token 各调一次。同一个函数，两个阶段——这就是 metrics 模块讲的 prefill/decode 二分。
+
+拆开看：
+
+**Prefill（预填充）** —— 吃完整 prompt。用户给你一段 prompt，你要把它全部过一遍模型，才能吐第一个 token。这一阶段你手里有一整段 token 可以并行处理（一个大 batch 的 matmul），**算力密集**（compute-bound，瓶颈在乘加运算量）。它决定的指标是 **TTFT**（time to first token，首 token 延迟）——prompt 越长，prefill 越久，用户等第一个字出来的时间越长。
+
+**Decode（解码）** —— 逐 token 生成。prompt 吃完之后，每生成一个新 token 只是对**一个**位置做一次前向（复用 KV cache）。这里每步只算一个 token 的 matmul，但要把整个 KV cache 从内存里读一遍——计算量小、数据搬运大，**访存密集**（memory-bound，瓶颈在内存带宽）。它决定的指标是 **tok/s** 和 **ITL**（inter-token latency，token 间延迟）。
+
+这俩的性质是**相反**的，这点怎么强调都不过分。`core/metrics.ts` 里 `interTokenLatency` 的注释直接给了 decode 阶段的健康判据:
+
+```typescript
+// decode 是推理二分的另一半：prefill 之后，每个新 token 是对单个位置做一次前向（复用 KV cache）。
+// 它的延迟应该大致是平的（而且远小于 TTFT）——如果 mean 随 step index 稳步上升，
+// 说明你的"缓存"在偷偷重读历史（这正是 stage02 要抓的 bug）。
+```
+
+也就是说：decode 的 per-step 延迟**应该是平的**。如果你测出来它随生成步数线性上涨，那不是模型大,是你的 KV cache 漏了——你以为在复用，其实每步都在重读整段历史，O(seq) 退化回 O(seq²)。这是个能用数据直接抓出来的 bug，第 02 章会演示。
+
+✦ 现在可以给出本书第一条、也是最重要的一条判断了：**资深推理工程师拿到一个慢的推理服务，第一反应不是"模型多大"，而是"你是 prefill bound 还是 decode bound"。** 这个问题的答案直接决定你该往哪个方向使劲，而且两个方向**相反**：
+
+- 你是 **decode bound**（短 prompt、长输出、并发请求多）→ 该上**批处理**（batching）。decode 访存密集、单请求把内存带宽喂不饱，把多个请求的 decode 步拼成一个大 batch，用一次内存搬运服务多个序列，吞吐成倍涨。这是第 04 章连续批处理（continuous batching）干的事。
+- 你是 **prefill bound**（长 prompt、短输出，比如 RAG 把一大堆检索结果塞进 context）→ 批处理帮不上多少忙，你要砍的是 TTFT，方向是投机解码（让一次前向多产出几个 token）、prefill 分块、或者干脆把 prompt 的 KV 缓存复用起来。
+
+方向选错，优化白做。一个被 4k token 长 prompt 拖死 TTFT 的服务，你给它上再大的 batch 也救不了首 token 延迟。"先量是哪种 bound，再决定上哪种优化"——这是贯穿全书的方法论，不是某一章的技巧。
+
+⚡ 这条两阶段二分在 2024-2025 已经被推到了**集群架构层**：既然 prefill 算力密集、decode 访存密集，性质相反，为什么要让它们抢同一台机器的资源？于是有了 **disaggregated serving**（分离式服务）——把 prefill 和 decode 拆到不同的机器池，各自用最适配的硬件配置，prefill 算完把 KV cache 通过高速网络传给 decode 池。vLLM 的 P/D 分离、Mooncake 都是这个路子。这是**正在落地、但远未成定论**的方向：KV cache 跨机传输的带宽和延迟代价、两个池的容量配比怎么动态调、传输失败怎么容错，都还在工程探索中。本书的 toy 引擎不碰集群，但你在第 02-05 章手写 KV cache 和分页时建立的直觉，正是理解为什么大厂要把这条二分推到机器层的基础。
+
+## 第三件事：衡量推理只有四把尺子
+
+知道了推理是自回归、分两阶段，接下来的问题是:**怎么知道一个优化到底有没有用?** 这本书的承诺是"会算真实 tok/s",这个承诺的生死全压在一个文件上——`examples/llm-inference-from-scratch/src/core/metrics.ts`。它把衡量推理的四把尺子钉成了代码,后面每一个 stage 都用同一套函数打分,不允许各章自己发明记法。
+
+四把尺子是:
+
+### 尺子一:吞吐(tok/s)
+
+headline 数字。`tokensPerSecond(nTok, ms)` 就是生成的 token 数除以墙钟时间(wall-clock,真实流逝的时间)。注意它的设计取舍——计时函数 `timeIt` **故意不内置 warmup**:
+
+```typescript
+// Warmup 约定(最容易搞错的地方):任何 JS 热路径的第一次调用都要付 JIT 编译 + 冷缓存的钱,
+// 这跟稳态吞吐无关。所以调用方必须在测量前先 warmup:
+//     timeIt(() => run());          // 丢弃:触发 JIT,热身缓存
+//     const ms = timeIt(() => run()); // 这一次才算数
+export function timeIt(fn: () => void): number {
+  const t0 = performance.now();
+  fn();
+  return performance.now() - t0;
+}
+```
+
+为什么不把 warmup 焊进 `timeIt`?因为有些测量(TTFT、第一个 token)**就是要测冷路径**,给它们热身就是撒谎。把"要不要热身"这个决定逼到调用点,诚实才看得见。这是本书第一条工程纪律:**任何 duration 都用 `performance.now()` 真测,绝不估算、绝不硬编码**。
+
+### 尺子二:延迟(TTFT / ITL)
+
+`ttft(ms)` 和 `interTokenLatency(msPerStep[])`。前者是 prefill 决定的首 token 延迟,后者是 decode 决定的 token 间延迟统计(mean/p50/p95)。这两个指标把上一节的 prefill/decode 二分直接显式化进了代码——TTFT 随 prompt 长度涨,ITL 应该平。一个交互式 chat 应用,用户对 TTFT 敏感(等多久看到第一个字);一个批量离线任务,只关心 tok/s。同一个引擎,两类负载,看的尺子不同。
+
+### 尺子三:显存 / 内存
+
+`estimateKVBytes(cfg, seqLen, nSeqs)`——这是**精确算术,不是测量**:
+
+```typescript
+// 这是精确算术,不是测量:KV cache 每层为每个序列的每个历史 token 存 key 和 value。
+// 每层形状:2(K 和 V) * nKVHeads * dHead * seqLen,再乘 nLayers,再乘 nSeqs。
+export function estimateKVBytes(cfg: ModelConfig, seqLen: number, nSeqs: number): number {
+  const bytesPerFloat = 8; // float64 payload
+  const elemsPerLayer = 2 * cfg.nKVHeads * cfg.dHead * seqLen;
+  return elemsPerLayer * cfg.nLayers * nSeqs * bytesPerFloat;
+}
+```
+
+这里有个刻意的诚实约定:**内存一律按 float64 payload 估算并标 `(est.)`,不读 `process.memoryUsage().rss`**。为什么?因为带 GC(垃圾回收)的 VM 上,RSS(常驻内存)噪声极大、依赖分配器、会对"算法本身的内存占用"撒谎。而 KV cache 的字节数学是对 model config 的精确算术——**这正是真实引擎做容量规划用的那个数**。注意它用的是 `nKVHeads` 不是 `nHeads`:这就是 GQA(grouped-query attention,多个 query 头共享一组 KV 头)省内存的地方——KV 头比 query 头少多少,缓存就小多少倍。这个公式是为什么需要分页 KV(第 05 章)和 GQA 的根本原因,所以它放在 core,让每个 stage 都能引用。
+
+> **注意 toy 与真引擎的唯一分叉点就在这个 `8`**:真实引擎的 KV cache 多是 fp16(2 字节),比这小 4 倍。本书的绝对内存数字偏大,但公式的**形状**和**比例**完全迁移。
+
+### 尺子四:输出等价性
+
+这是最容易被偷工减料、也是本书最较真的一把尺子。一个优化"跑起来了"不等于"没改变输出"。`metrics.ts` 提供两个判官:
+
+- `perplexity(logits, targetIds)`——困惑度,证明"快但没变差"。优化后的 run 和 baseline run 困惑度近乎相同,是优化保留了分布的硬证据。它专抓一类 bug:一个量化方案"能跑",但悄悄扭曲了输出分布,即便 argmax(最大概率那个 token)恰好没变,困惑度也会露馅。
+- `maxLogitDrift(a, b)`——两个 logit 向量的 L∞(最大绝对)差。任何内核改写或量化的"在线"正确性检查。本应完全相同的两个 logit 向量(同模型同输入、不同代码路径)在 float64 下必须漂移 ~0。注释里讲了为什么报 L∞ 而不是平均值:**一个灾难性错误的 logit(比如一次溢出的点积)正是平均值会掩盖、却会翻转 argmax 的那种失败**。
+
+```typescript
+// maxLogitDrift:报 L∞(不是 mean)是刻意的——单个灾难性错误的 logit
+// 正是 mean 会藏起来、却会翻转 argmax 的那种失败。
+export function maxLogitDrift(a: number[], b: number[]): number { /* ... */ }
+```
+
+把等价性钉成可计算的数(困惑度差、logit 漂移),而不是嘴上说"没变质",是这本书对抗"AI 批量生成的 survey 稿"的核心姿态——后者会告诉你"int8 量化几乎不损失精度",本书会让你跑 `npm run stage07` 看那个 L∞ 漂移到底是几。
+
+## toy 引擎全景:每章 stage 在这张地图的坐标
+
+把三件武器(自回归、两阶段、四把尺子)装备好,现在看整张地图。配套仓 `examples/llm-inference-from-scratch/` 的结构是:`src/core/` 是所有 stage 复用的底座,每个 stage 一条 `npm run` 命令、加载即跑。
+
+底座 `src/core/`(本章引用的全部代码都在这):
+
+| 文件 | 职责 | 本章用到的关键导出 |
+|------|------|--------------------|
+| `core/tensor.ts` | toy 张量与算子内核(matmul/rmsNorm/softmax/silu/rope/causalMask),row-major Float64Array,无 BLAS,慢但确定可读 | `rope`(为什么 KV cache 能成立的几何原因)、`softmax`(减 max 防溢出) |
+| `core/model.ts` | toy LLaMA 风格 decoder(RMSNorm + RoPE + GQA + SiLU-gated FFN + 权重绑定) | `forwardNoCache`(参考路径)、`forwardStep`(缓存路径)、`KVCache` 类型 |
+| `core/tokenizer.ts` | byte 级确定性 tokenizer(vocab=256,零词表文件),`encode`/`decode` 离线 round-trip | `PROMPTS`(≥3 个不同长度,故意防 N=1 巧合) |
+| `core/metrics.ts` | 推理诚实记分卡 | `tokensPerSecond` / `ttft` / `interTokenLatency` / `estimateKVBytes` / `speedup` / `perplexity` / `maxLogitDrift` |
+
+为什么 tokenizer 要备 3 个不同长度的 prompt(`PROMPTS`)?它的注释说得直白:单个 prompt 有 N=1 撞运气的风险——某个长度恰好对齐了第 05 章的页边界、或某个 TTFT 恰好看着平。跨这一组长度报指标,才是"它能用"而不是"它跑通过一次"的区别。这是贯穿全书测量纪律的缩影。
+
+每章 stage 的坐标(对应 `npm run stageXX`,均在本章的两阶段地图上各占一格):
+
+| Stage | 命令 | 优化哪个阶段 | 用本章哪把尺子证明 |
+|-------|------|-------------|-------------------|
+| 01 forward pass | `stage01` | 建 baseline(参考前向) | tok/s baseline |
+| 02 KV cache | `stage02` | **decode**:O(seq²)→O(seq) | speedup + maxLogitDrift(等价) |
+| 03 sampling | `stage03` | decode 的采样策略 | 输出多样性,非速度 |
+| 04 continuous batching | `stage04` | **decode**:多序列共享前向,喂饱内存带宽 | tok/s(吞吐) |
+| 05 paged KV | `stage05` | **decode**:消除按步重分配的拷贝 | estimateKVBytes + speedup |
+| 06 speculative decoding | `stage06` | **prefill/decode 串行瓶颈**:draft+verify | speedup + perplexity(等价) |
+| 07 quantization | `stage07` | 内存 + 带宽:fp64→int8 | maxLogitDrift(漂移多少) |
+| 08 benchmark | `stage08` | 全局汇总 | 四把尺子的诚实记分卡 |
+
+注意第 02、04、05 都在打 **decode**(因为绝大多数线上负载是 decode bound),第 06 啃的是自回归串行瓶颈本身,第 07 既省内存又省带宽。**每个 stage 都是在回答同一个问题:"让哪个阶段更快、代价是什么"**——这就是上面那条"先量是哪种 bound"的判断在每一章的落地。
+
+> 关于数字的诚实声明,每个 stage 都会复述一遍:toy 模型小、内核是未优化的 float64 循环,所以**绝对 tok/s 偏悲观**;能迁移到真实引擎的是**相对趋势**和**加速比**。内存按 float64 payload 估算并标 `(est.)`,不测 RSS。等价性用困惑度 / logit 漂移证明,不靠嘴说。**本章不绑独立 stage,所以不报任何运行数字——上文所有数字(O(seq²)、`bytesPerFloat = 8`、vocab=256 等)都是代码里的常量或算法复杂度,不是测量结果。** 真正的实测 tok/s 从第 02 章 `npm run stage02` 开始出现。
+
+读完这一章,你手里有三样东西:知道推理为什么是 N 次串行前向(自回归)、知道每次生成都分裂成性质相反的 prefill 与 decode、知道用哪四把尺子判断一个优化的真假。带着"我现在是 prefill bound 还是 decode bound"这个问题,翻到第 02 章——我们从手写 KV cache 开始,把 `forwardNoCache` 那条 O(seq²) 的参考路径,真正砍成 `forwardStep` 的 O(seq)。

--- a/src/content/library/llm-inference/01-TinyTransformer前向.md
+++ b/src/content/library/llm-inference/01-TinyTransformer前向.md
@@ -1,0 +1,253 @@
+---
+title: "Tiny Transformer 前向：从 token 到 logits，手算每一步"
+slug: "01"
+collection: "llm-inference"
+order: 1
+summary: "全书第一章，建立后续所有优化的'正确性基准'：用纯 TypeScript 手写一个 4 层 GQA decoder 的完整前向，embedding 查表到 vocab logits 全程不调矩阵库。逐算子追踪激活尺度证明 RMSNorm 的不变量、实测注意力的 O(seq²) 增长曲线（这是第 2 章 KV 缓存要消灭的成本）、并跑出 softmax 不减 max 时的 NaN 失败。后续每一章（KV 缓存、采样、连续批处理、分页、投机、量化）都要跟本章的 golden logits 对拍，才算正确。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+要给一个推理引擎做加速，你得先有一个慢得诚实、对得无可争议的东西作为对照。这一章就是造那个东西：一个 4 层、64 维、用 GQA（分组查询注意力，多个查询头共享一组 KV 头）的 decoder，从 token id 算到 256 维 vocab logits，全程手写。不调 BLAS（高性能矩阵库），不调任何 tensor 框架，matmul / softmax / RoPE / RMSNorm 全是 for 循环。
+
+为什么要这么自虐？因为后面六章每一个加速——KV 缓存、连续批处理、分页 KV、投机解码、量化——本质都是「换一种更快的方式算出同一个 logits」。「同一个」三个字需要一个 ground truth（真值基准）来界定。本章末尾产出的 golden logits 就是它：后续任何优化跑完，最后一个 token 的 logits 必须跟本章对得上（float64 噪声内），对不上就是 bug，不管它跑得多快。
+
+先说清楚一件容易误会的事。本章的模型权重是用固定种子的 PRNG 随机生成的合成权重（`buildModel(cfg, SEED)`），模型**没训练过**，所以输出的 logits 是「结构正确的乱码」——argmax 出来的 token 没有任何语言意义。这没关系。本章讲的是前向**机制**，不是输出质量。机制对不对，看的是激活尺度的不变量、计算量的增长形状、数值稳定性这些可验证的东西，跟权重训没训练无关。
+
+配套代码在 `examples/llm-inference-from-scratch/src/core/`（被复用的算子）和 `examples/llm-inference-from-scratch/src/stage01-forward.ts`（本章的可跑实验）。基线配置写死在 `core/model.ts`：
+
+```ts
+export const DEFAULT_CONFIG: ModelConfig = {
+  dModel: 64,
+  nLayers: 4,
+  nHeads: 4,
+  dHead: 16,
+  dFF: 256,
+  vocabSize: 256, // byte-level, matches core/tokenizer
+  maxSeq: 256,
+  nKVHeads: 2,
+};
+```
+
+注意 `nKVHeads: 2` 小于 `nHeads: 4`——默认就开了 GQA，4 个查询头分 2 组，每组共享一个 KV 头。这不是凑数，是为了让第 2 章的 KV 缓存差异（GQA 把 KV 缓存砍一半）从第一章起就在数据里可见。
+
+## 一次前向到底在算什么
+
+整条管线是一个固定的序列。先把 token id 当下标去 embedding 表里查出一行向量（embedding 就是「token → 向量」的查表），然后这行向量过 `nLayers` 个完全相同结构的 block，每个 block 内部是：
+
+```
+RMSNorm → 多头自注意力(带因果掩码) → 残差加 → RMSNorm → SwiGLU FFN → 残差加
+```
+
+最后过一次末层 RMSNorm，再用 lm_head（输出投影，本书用 weight tying 复用 embedding 矩阵）投到 vocab 维度，得到每个候选 token 的 logit。
+
+`core/model.ts` 里的 `blockStep` 就是一个 block 的全部，结构和上面这行一字不差：
+
+```ts
+function blockStep(h, w, pos, kHist, vHist, histLen, cfg) {
+  // pre-norm
+  const normed = rmsNorm(tensor(h, [1, cfg.dModel]), w.normAtt).data;
+  const { q, k, v } = projectQKV(normed, w, cfg);
+  applyRope(q, k, pos, cfg);
+  // ... 拼接 KV 历史，attendToken 算注意力 ...
+  const attnOut = matmul(tensor(attn, [1, cfg.nHeads * cfg.dHead]), w.wO).data;
+  // residual
+  const h1 = new Float64Array(cfg.dModel);
+  for (let i = 0; i < cfg.dModel; i++) h1[i] = h[i] + attnOut[i];
+  // FFN sub-block, pre-norm + residual
+  const normed2 = rmsNorm(tensor(h1, [1, cfg.dModel]), w.normFFN).data;
+  const ff = ffn(normed2, w, cfg);
+  const h2 = new Float64Array(cfg.dModel);
+  for (let i = 0; i < cfg.dModel; i++) h2[i] = h1[i] + ff[i];
+  return { h: h2, k, v };
+}
+```
+
+这是「pre-norm」结构（先 norm 再进子层），现代 decoder 几乎都这么做：norm 放在残差分支里面，主干（residual stream）始终是一条没被 norm 动过的「干净加法线」。下面追踪激活尺度时你会看到，主干的幅度随层累加越长越大，而每次喂给子层之前都被 RMSNorm 拉回单位尺度——这个拉回是深层网络不爆炸的核心机制。
+
+### 每个 Float64Array 都能指着说出物理含义
+
+本章的第一个实验 `[a]` 就是把上面这个 block 拆成单算子，逐个打印激活的统计量（mean / std / rms / |max|）。目的很朴素：让你能指着每个 `Float64Array` 说出它是什么、尺度多大。下面是真实运行输出（layer 0，一个 235-token prompt 的最后一个 token，pos=234）：
+
+```
+config: dModel=64 nHeads=4 nKVHeads=2 dHead=16 dFF=256
+embed (block input)    mean=   0.0080  std=   0.0778  rms=   0.0782  |max|=   0.1232
+RMSNorm(att)           mean=   0.1018  std=   0.9948  rms=   1.0000  |max|=   1.5678
+Q proj                 mean=   0.0568  std=   0.6143  rms=   0.6170  |max|=   1.5224
+K proj                 mean=  -0.1001  std=   0.4745  rms=   0.4849  |max|=   0.9852
+V proj                 mean=   0.0798  std=   0.5434  rms=   0.5492  |max|=   1.1607
+Q after RoPE           mean=   0.1273  std=   0.6037  rms=   0.6170  |max|=   1.5693
+attention output       mean=  -0.0277  std=   0.1169  rms=   0.1202  |max|=   0.2307
+attn out-proj (wO)     mean=   0.0100  std=   0.0639  rms=   0.0647  |max|=   0.1615
+after attn residual    mean=   0.0180  std=   0.1029  rms=   0.1045  |max|=   0.2795
+RMSNorm(ffn)           mean=   0.1715  std=   0.9844  rms=   0.9993  |max|=   2.6601
+SiLU-gated hidden      mean=  -0.0167  std=   0.1614  rms=   0.1622  |max|=   1.0244
+FFN down-proj          mean=  -0.0014  std=   0.0840  rms=   0.0840  |max|=   0.2341
+block output           mean=   0.0166  std=   0.1344  rms=   0.1355  |max|=   0.3652
+=> RMSNorm invariant: both norm outputs have rms ~ 1 (1.000, 0.999) — HOLDS
+```
+
+盯着 `rms` 这一列看。embed 进来时 rms 是 0.0782（一个很小的数，因为权重按 `1/sqrt(fanIn)` 初始化），过一次 `RMSNorm(att)` 立刻变成 1.0000。这就是 RMSNorm 的全部工作：不管输入幅度是多少，输出的均方根永远是 1（乘上每维的 gain，gain 初始化在 1 附近）。
+
+`core/tensor.ts` 的 `rmsNorm` 干的就是这件事——没有减均值，没有 bias，只有「除以自己的 rms」：
+
+```ts
+export function rmsNorm(x, weight, eps = 1e-6) {
+  // ...
+  const inv = 1 / Math.sqrt(ss / n + eps);
+  for (let j = 0; j < n; j++) out[row + j] = x.data[row + j] * inv * weight.data[j];
+  // ...
+}
+```
+
+再看 `after attn residual` 那行：rms 从注意力输出的 0.0647（attn out-proj）跳到 0.1045。这是残差加法——`h1 = h + attnOut`，主干把子层的输出**加**了进来，所以幅度比任一加数都大。然后下一行 `RMSNorm(ffn)` 又把它拉回 0.9993。这一升一降在每个 block、每一层反复发生：残差让主干单调增长，RMSNorm 在每个子层入口把它归一。一个深网络能堆 4 层、40 层、100 层而不在第三层就 overflow 成 NaN，靠的就是这个不变量。
+
+代码末尾把它写成了一个被检查的断言，不是凭感觉说「看起来 norm 了」：
+
+```ts
+const ok = Math.abs(normedRms - 1) < 0.1 && Math.abs(normed2Rms - 1) < 0.1;
+```
+
+这是本书的一个基本态度：每个声称的不变量都要有一行代码去验证它，输出里打 `HOLDS` 或 `VIOLATED`，不留「我觉得对」的空间。
+
+### RoPE 是一次旋转，所以它不改 rms
+
+顺手看一个能当 sanity check（健全性检查）的细节。`Q after RoPE` 那行的 rms 是 0.6170，跟 RoPE 之前 `Q proj` 的 0.6170 **完全相等**。这不是巧合：RoPE（旋转位置编码，用「转角度」的方式把位置信息塞进 Q/K）的本质是对每一对维度做二维旋转，而旋转保模长。`core/tensor.ts` 的 `rope` 就是标准的二维旋转矩阵：
+
+```ts
+const cos = Math.cos(angle);
+const sin = Math.sin(angle);
+q[i] = q0 * cos - q1 * sin;
+q[i + 1] = q0 * sin + q1 * cos;
+```
+
+所以如果你 RoPE 实现错了（比如转角符号搞反、配对维度配错），rms 会偏移。「RoPE 后 rms 不变」是一个免费的正确性探针。
+
+RoPE 还藏着第 2 章的伏笔：它编码的是**相对**位置——位置 i 的 query 和位置 j 的 key 之间的注意力分数只依赖 `(i - j)`。这意味着一个在位置 5 算出来的 key，它的旋转是「位置 5 的绝对旋转」，永远冻结、永远有效，不会因为后面又来了 100 个 token 就失效。这正是 KV 缓存能成立的几何理由：缓存的 K/V 不需要重算。本书把 RoPE 放在 `core/` 而不是某个 stage 里，就是因为它是缓存正确性的根。
+
+## 注意力为什么是 O(seq²)，以及它为什么必须
+
+现在讲这一章最重要的成本论点。注意力要为**每一对** (query, key) 算一个分数。一个 query token 看 `len` 个 key，就是 `len` 次点积；而一次完整前向里有 seq 个 query token，因果约束下第 i 个 token 看 0..i 共 i+1 个 key，加起来是 `seq*(seq+1)/2` 对——这就是平方。
+
+`core/model.ts` 的 `attendToken` 是注意力的核心，那个 `for p` 循环就是平方的来源：
+
+```ts
+for (let hh = 0; hh < cfg.nHeads; hh++) {
+  const kvHead = Math.floor(hh / groupSize); // GQA: 这个 query 头读哪个 KV 头
+  const scores = new Float64Array(len);
+  for (let p = 0; p < len; p++) {          // <- 对每个缓存位置算一个分数
+    const kOff = p * (cfg.nKVHeads * cfg.dHead) + kvHead * cfg.dHead;
+    let dotv = 0;
+    for (let d = 0; d < cfg.dHead; d++) dotv += q[qOff + d] * kAll[kOff + d];
+    scores[p] = dotv * invSqrtD;
+  }
+  const probs = softmax(tensor(scores, [1, len])).data;
+  // ... 用 probs 加权求和 V ...
+}
+```
+
+本章实验 `[b]` 把这条「无缓存参考路径」（`forwardNoCache`）在 seq = 16/32/64/128 上跑，打印点积数和墙钟时间。真实输出：
+
+```
+seq | qk-dot-products | wall-clock ms | ms/seq^2 (x1e-6) | growth vs prev
+ 16 |            2176 |         5.049 |        19723.242 | —
+ 32 |            8448 |        10.169 |         9930.892 | 2.01x for 2x seq
+ 64 |           33280 |        21.136 |         5160.205 | 2.08x for 2x seq
+128 |          132096 |        45.000 |         2746.606 | 2.13x for 2x seq
+```
+
+先看 `qk-dot-products` 列：2176 → 8448 → 33280 → 132096。seq 翻倍，点积数恰好翻 4 倍（精确平方，因为它就是 `seq*(seq+1)/2 * nHeads * nLayers` 算出来的解析值，不是测量值）。这是确定的、无可争议的平方。
+
+墙钟那列要看得更仔细，这里有个**实测的陷阱**。`growth vs prev` 是 2.01x → 2.08x → 2.13x。如果整个前向是纯 O(seq)，每次 seq 翻倍时间应该恰好翻 2.0 倍。实际比值在 2.0 之上爬，但爬得很慢——为什么不是 4 倍？
+
+因为在这个**玩具尺寸**下，每个 token 的 O(seq) 工作（FFN、Q/K/V 投影，这些跟序列长度无关、只跟 token 数成正比）才是耗时大头，注意力的 O(seq²) 项还很小。总时间 = O(seq) 的线性大头 + O(seq²) 的平方小头，所以归一化的 `ms/seq²` 那列在玩具尺寸下反而随 seq 下降（线性项被 seq² 一除越来越小）。平方的签名不在绝对数里，而在**增长比超过 2.0 这件事**上——2.01 → 2.08 → 2.13 就是平方项在线性大头之上开始冒头。模型更大、序列更长时，注意力会反超，这列才会压平。
+
+这是本书反复强调的诚实：**绝对毫秒数是悲观的**（toy float64 循环，没做任何 kernel 优化），能迁移到真实引擎的是**形状**（平方）和**不变量**，不是这几个 ms。把玩具的绝对耗时当真，是读这类「从零手写」材料最常见的误读。
+
+### 因果掩码为什么必须
+
+`attendToken` 上面那段代码里其实没有显式的掩码——注释写着「the cache *is* the mask」（缓存本身就是掩码）。这是缓存路径的取巧：调用方只缓存「过去 + 当前」这些 token，未来的 token 根本没进 `kAll`，所以不需要额外屏蔽。但「无缓存参考路径」`forwardNoCache` 是逐 token 推进、每个 token 只拿到 `histLen+1` 个 K/V，效果一样：token i 物理上拿不到 i 之后的 key。
+
+为什么必须？因为这是 decoder 的因果性（causality）：训练时模型要预测下一个 token，如果它能「看到」未来的答案，训练就是作弊，推理时也会行为错乱。`core/tensor.ts` 提供了一个独立的 `causalMask`，用来给一次性算整个 [seq, seq] 分数矩阵的实现加掩码，它的注释点出了一个真实的暗坑：
+
+```ts
+// 0 on/below the diagonal, -Infinity above it.
+out[i * seq + j] = j > i ? -Infinity : 0;
+```
+
+注意是 `-Infinity`，不是 `-1e9`。为什么不用一个大负数？因为 `exp(-Infinity) = 0`，masked 位置的 softmax 权重**精确**为 0；而 `exp(-1e9)` 在 float64 里也是 0，看起来没差，但如果有人图省事写成 `-1e9`、再被某个量化或低精度路径放大，就会留下 ~1e-9 的「泄漏」——token 偷看到了一点点未来。一两层看不出来，叠 40 层后是一个真实存在、极难定位的正确性 bug。用 `-Infinity` 是把这个漏洞从源头堵死。
+
+> ✦ **面试高频暗坑。** 能背出注意力公式 `softmax(QKᵀ/√d)V` 的人很多，能说清「为什么 decode 阶段每一步的 Q 只有 1 行、KV 却是整段」的人少。看 `attendToken`：query `q` 是单个 token 的向量（`qOff = hh * dHead`，一个头一行），但 `kAll` / `vAll` 是从位置 0 到当前的**整段**。生成第 N 个 token 时，新 token 的 Q 只跟它自己有关（1 行），但它要去注意前面所有 N-1 个 token 的 K/V（N 行）。这一行 vs 整段的不对称，就是 KV 缓存存在的全部理由：Q 每步都新算无所谓（就 1 行），但 K/V 如果每步都把整段重算，就是 `forwardNoCache` 的 O(seq²) 灾难。把已经算过的 K/V 存下来复用，每步就只多算 1 行 K/V，前向从 O(seq²) 降到 O(seq)。这是第 2 章的全部内容，而它的正确性证明，就是缓存路径的 last-token logits 必须等于本章 `forwardNoCache` 的 golden logits。
+
+> ⚡ **开放问题：那堵平方的墙。** 注意力的 O(seq²) 不是实现笨，是数学定义如此——每对 token 都要交互。当 context 从 4K 涨到 128K、1M，平方项就从「玩具里看不见的小头」变成「吃掉一切的主项」。2024–2025 的一大批架构就是冲着绕开这堵墙去的：线性注意力、状态空间模型（SSM，如 Mamba-2）、RWKV，以及把它们和标准注意力混搭的混合架构。它们的共同思路是用一个**固定大小**的状态（而不是随 seq 线性增长的 KV 缓存）来概括历史，把每步成本压成 O(1)、整体压成 O(seq)。代价是这个固定状态是有损压缩，长程精确召回（比如「大海捞针」式的精确检索）通常打不过老老实实存全部 KV 的标准注意力。**目前没有通用解**：哪种架构能在「线性成本」和「不丢长程信息」之间取得对所有任务都更优的平衡，仍在研究中，工业界主流模型 2025 年仍以标准注意力 + KV 缓存优化（分页、量化，本书后面几章）为主。理解了本章这个精确的平方代价，你才知道那些新架构到底在省什么、又拿什么换。
+
+## 失败模式：softmax 不减 max 会 NaN
+
+注意力的最后一步是 softmax，把分数变成一个概率分布。这里有推理数值学里**最经典的一课**：永远不要直接对原始 logit 取 exp。
+
+`core/tensor.ts` 的 `softmax` 在 exp 之前先减去了每行的最大值：
+
+```ts
+let max = -Infinity;
+for (let j = 0; j < cols; j++) if (x.data[row + j] > max) max = x.data[row + j];
+let sum = 0;
+for (let j = 0; j < cols; j++) {
+  const e = Math.exp(x.data[row + j] - max);  // <- 减 max 是关键
+  out[row + j] = e;
+  sum += e;
+}
+```
+
+减 max 在数学上不改结果（分子分母同乘一个常数），但让最大的那个指数恰好是 `exp(0) = 1`，其余都 ≤ 1，永不溢出。不减会怎样？本章实验 `[c]` 直接证给你看。
+
+它先用本章 `[a]` 真实捕获的那一行注意力分数（235 个位置，max logit = 1.103）跑「减 max」和「不减 max」两个版本：
+
+```
+real attention scores (len=235, max logit=1.103): naive vs stable max prob drift = 4.34e-18 (agree — toy logits are too small to overflow)
+```
+
+两者一致，drift 是 4.34e-18（浮点噪声级别）。这恰恰是**危险**的地方：在玩具的小 logit 下，错误的实现**看起来完全正确**。它不是「总是坏」，是「有条件地坏」——这种 bug 最难抓，因为你的测试可能永远命中不了触发条件。
+
+然后实验把同一行真实分数线性放大，把最大 logit 推到 800（`exp(800)` 远超 float64 的 ~1.8e308 上限）。注意这不是凭空捏造一个 NaN，是拿真实数据做了一个变换。结果：
+
+```
+amplified scores (max logit=800.0, exp(800) overflows float64):
+  naive softmax  -> hasNaN=true  sum=NaN  [first 3: 0.00e+0, 0.00e+0, 0.00e+0]
+  stable softmax -> hasNaN=false  sum=1.000000  [first 3: 0.00e+0, 0.00e+0, 0.00e+0]
+=> PROVEN: max-subtraction is load-bearing — naive path NaNs, stable path stays a valid distribution (sum=1).
+```
+
+不减 max 的版本：`exp(800)` = Infinity，sum = Infinity，`e / Infinity` 产生 NaN，整行分布污染成 NaN，hasNaN=true。减 max 的版本：sum = 1.000000，仍是一个合法概率分布。这就是「减 max 是 load-bearing（承重的）」的实测证据——它不是装饰，拆了就塌。
+
+这里要诚实标注一个边界：在本章的 toy 配置下，float64（约 1.8e308 上限）其实**扛得住**真实模型那种 +40..+80 的注意力 logit（`exp(80) ≈ 5.5e34`，没溢出）。所以 `[c]` 是把分数**人为放大到 800** 才触发的失败。但 `core/tensor.ts::softmax` 的注释点出了为什么这一课在真实引擎里不是玩具问题：float32（`exp(89) = inf`）扛不住，第 7 章的量化路径更扛不住。减 max 让结果在「精确算术下完全相同」但「任何精度下都不溢出」——这正是为什么所有真实 kernel（包括 FlashAttention 那套在线 softmax）都把减 max 当成不可省的第一步。本书把减 max 写成无条件的，就是为了让这一课在每一行 softmax 上都成立、行为在不同精度间一致。
+
+## Golden logits：后续所有章节的对拍基准
+
+最后，实验 `[d]` 产出本章的交付物：三个不同长度 prompt 的 last-token logits 的指纹（argmax token + argmax 的 logit 值 + 平均 logit + 一个 order-sensitive 的 checksum）。三个 prompt 来自 `core/tokenizer.ts::PROMPTS`，长度故意拉开（避免 N=1 的运气）。真实输出：
+
+```
+prompt(len) | argmax tok | logit[argmax] | mean logit | checksum
+p0(  3)     |        112 |        1.9430 |    -0.0338 | -1.473068e+3
+p1( 48)     |          2 |        1.5833 |     0.0045 | 3.655462e+2
+p2(235)     |         46 |        1.5365 |    -0.0408 | -2.149947e+3
+=> determinism: two independent builds drift by 0.00e+0 (must be 0 for golden to be a valid reference)
+```
+
+最后那行是 golden 能成立的前提：用同一个种子独立 build 两次模型、各跑一次前向，两次的 logits 逐元素 drift 是 **0.00e+0**——bit-for-bit 一致。这不是运气，是设计。`core/model.ts` 用的 `mulberry32` 是一个可种子化的 PRNG，整个模型 `buildModel(cfg, seed)` 是 `(cfg, seed)` 的纯函数，加上前向全是确定性 float64 运算，所以输出可完全复现。
+
+为什么这件事是地基级的？因为后续每一章的正确性证明都是「我的新路径 reproduce 了本章的 golden」。如果 golden 自己都不确定（两次 build 漂移非零），那所有跨章节的对比都建在沙子上。所以代码把它写成一个 loud assertion，drift 必须是 0，不是「差不多」。
+
+checksum 用的是一个 order-sensitive 的滚动求和，不是密码学哈希，只是一个便宜的、确定的指纹——任何一个 logit 变了它就变。256 个 float 全打出来没法读，打一个 checksum + argmax + 几个统计量，足够检测任何漂移，又小到能一眼扫。
+
+## 小结：这一章给后面留下了什么
+
+你现在手里有一个慢得诚实的前向。它建立了三件后面要反复引用的东西：
+
+1. **RMSNorm 不变量**——每个子层入口 rms ≈ 1，是深层不爆炸的机制（实测 1.000 / 0.999 HOLDS）。后面任何改动若让某层 rms 跑飞，第一个该怀疑的就是它。
+2. **注意力的 O(seq²)**——精确平方的点积数（2176 → 132096）和「增长比超过 2.0」的墙钟签名。第 2 章的 KV 缓存就是来把它降到 O(seq) 的，理由是那个「Q 一行、KV 整段」的不对称。
+3. **golden logits**——三个 prompt 的确定性指纹（drift = 0），后续 KV 缓存、采样、连续批处理、分页、投机、量化每一章都要对着它对拍。
+
+下一章（第 2 章）正式动手做 KV 缓存：把本章 `forwardNoCache` 里每步重算的整段 K/V 存下来复用，并用本章的 golden 证明它「更快但算出同一个东西」。

--- a/src/content/library/llm-inference/02-KV缓存.md
+++ b/src/content/library/llm-inference/02-KV缓存.md
@@ -1,0 +1,247 @@
+---
+title: "KV 缓存：把 decode 从 O(n²) 砍成 O(n) 的那一步"
+slug: "02"
+collection: "llm-inference"
+order: 2
+summary: "上一章把一次前向跑通、把 tok/s 量出来；这一章动第一刀，也是回报最大的一刀——KV 缓存。我们证明缓存不改变一个 bit 的输出（maxLogitDrift==0），却把 decode 每步从重算整段前缀降到只算一行，加速比随生成长度从 6.65x 涨到 42.31x。同时算清它的代价：KV cache 显存随序列线性膨胀，是后面 PagedAttention（第 5 章）和量化（第 7 章）要省的那本账。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+> 上一章我们把一次前向跑通、把 tok/s 量出来。这一章动推理引擎的第一刀，也是回报最大的一刀——KV 缓存。证明它不改变一个 bit 的输出，却把 decode 每步从重算整段前缀降到只算一行；再算清它的代价：那本越长越厚的显存账，是后面 PagedAttention（第 5 章）和量化（第 7 章）真正要省的对象。
+
+## 朴素自回归在重算什么
+
+先把浪费指出来，不然你不会觉得缓存值得做。
+
+自回归生成的规则是：模型一次吐一个 token，吐第 t 个的时候，注意力要看前面全部 t 个 token。最直白的实现就是——每生成一个新 token，把到目前为止的整段序列重新喂进模型从头跑一遍。这就是配套仓里的参照实现 `forwardNoCache`（`examples/llm-inference-from-scratch/src/core/model.ts`）：
+
+```ts
+export function forwardNoCache(model: Model, tokenIds: number[]): Float64Array {
+  // ...
+  for (let l = 0; l < cfg.nLayers; l++) {
+    // ...
+    for (let pos = 0; pos < seq; pos++) {
+      const r = blockStep(h[pos], w, pos, kHist, vHist, pos, cfg);
+      kHist.set(r.k, pos * kvDim);   // 每次调用都从零重算每个位置的 K/V
+      vHist.set(r.v, pos * kvDim);
+      newH.push(r.h);
+    }
+    h = newH;
+  }
+  return logitsFromHidden(h[seq - 1], model);  // 只用得上最后一个位置的 logits
+}
+```
+
+stage02 的 decode 循环（`src/stage02-kvcache.ts`）每生成一个 token 就把它 push 进序列、再 `forwardNoCache` 整段一遍：
+
+```ts
+function genTokensNoCache(nGen: number): { ids: number[]; lastLogits: Float64Array } {
+  const seq = [...promptIds];
+  let logits = forwardNoCache(model, seq);
+  const ids: number[] = [];
+  for (let i = 0; i < nGen; i++) {
+    const next = argmax(logits);
+    ids.push(next);
+    seq.push(next);
+    logits = forwardNoCache(model, seq); // re-runs the WHOLE prefix every step
+  }
+  return { ids, lastLogits: logits };
+}
+```
+
+浪费在哪？看那行注释 `// 只用得上最后一个位置的 logits`。整段重跑算出了所有 t 个位置的 hidden state，但下一个 token 只取决于最后一个位置。前 t-1 个位置的输出我们算了又扔。
+
+更要命的是注意力那一层。`blockStep` 里每个位置都要投影出自己的 Key 和 Value（`projectQKV`），但**前 t-1 个 token 在第 t 步算出的 K/V，跟它们在第 t-1 步算出的 K/V 一模一样**——同样的 token，同样的位置，同样的权重，同样的 RoPE 旋转角度。这不是近似相等，是 bit-for-bit 相等。每步把它们重算一遍，是纯粹的重复劳动。
+
+算笔账：第 k 步要为 k 个位置做投影，O(k) 的工作；生成 n 个 token，总成本 Σk = O(n²)。这个平方项就是朴素自回归不能用于服务的根本原因。注意一个常被讲糊的点：注意力打分（query 点乘所有 key）本身在两条路径里都是 O(n²)，KV 缓存省不掉它；缓存真正砍掉的是**投影和 FFN 的重复**——这部分占了绝大多数常数，所以总工作量塌缩成 O(n)。
+
+## KV 缓存：算一次，存下来，复用
+
+机制一句话说清：每个 token 的 K 和 V 第一次算出来就存进 cache，后面每一步只为当前这一个新 token 算 K/V（O(1) 投影），再拿它的 Q 对全量 cache 做一次注意力扫描。
+
+缓存的类型本身就是这本书的主角（`src/core/model.ts`）：
+
+```ts
+export type KVCache = {
+  k: Float64Array[]; // per layer: flat [len * kvDim] (we grow by pushing rows)
+  v: Float64Array[];
+  len: number; // number of positions currently cached (same for all layers)
+  cfg: ModelConfig;
+};
+```
+
+缓存路径 `forwardStep` 处理单个 token：它在绝对位置 `cache.len` 上跑，复用所有已缓存的 K/V，把这个 token 的 K/V 追加进 cache，返回它的 logits：
+
+```ts
+export function forwardStep(model: Model, tokenId: number, cache: KVCache): Float64Array {
+  const pos = cache.len;
+  // ...
+  for (let l = 0; l < cfg.nLayers; l++) {
+    const w = model.layers[l];
+    const r = blockStep(h, w, pos, cache.k[l], cache.v[l], pos, cfg);
+    // grow this layer's cache by one row (the just-computed K/V).
+    const grownK = new Float64Array((pos + 1) * kvDim);
+    grownK.set(cache.k[l].subarray(0, pos * kvDim));
+    grownK.set(r.k, pos * kvDim);
+    cache.k[l] = grownK;
+    // ...同样 append V
+    h = r.h;
+  }
+  cache.len = pos + 1;
+  return logitsFromHidden(h, model);
+}
+```
+
+这里有个值得记住的设计决策：**prefill 和 decode 是同一个函数**。把整段 prompt 灌进 cache 就是对每个 prompt token 调一次 `forwardStep`；decode 就是对每个生成的 token 调一次 `forwardStep`。同一个函数，两个阶段——这就是工程上常说的 prefill/decode 二分。stage02 的生产路径直接体现这点：
+
+```ts
+function genTokensCached(nGen: number): { ids: number[]; lastLogits: Float64Array } {
+  const cache = newCache(DEFAULT_CONFIG);
+  // prefill: run the prompt through, filling the cache.
+  let logits: Float64Array = new Float64Array(0);
+  for (const id of promptIds) logits = forwardStep(model, id, cache);
+  const ids: number[] = [];
+  for (let i = 0; i < nGen; i++) {
+    const next = argmax(logits);
+    ids.push(next);
+    logits = forwardStep(model, next, cache); // O(1) projection + O(len) attend
+  }
+  return { ids, lastLogits: logits };
+}
+```
+
+### 一个容易被吞掉的实现细节：cache IS the mask
+
+`attendToken` 里没有任何显式的 causal mask（因果掩码，即不让 token 看到它后面的内容）：
+
+```ts
+// scores against every cached position (causal: caller only ever caches the past
+// plus the current token, so no explicit mask needed here — the cache *is* the mask).
+const scores = new Float64Array(len);
+for (let p = 0; p < len; p++) { /* dot product over all len positions */ }
+```
+
+为什么不需要 mask？因为缓存里**只有**过去的 token 加当前这一个。当前 token 物理上看不到未来——未来还没生成，根本不在 cache 里。这跟 `forwardNoCache` 里靠 `blockStep(..., pos, ...)` 传 `histLen=pos` 来限制可见范围是等价的两种实现因果性的方式。把这点记牢，到第 4 章 continuous batching 拼 batch、第 5 章 paged-KV 切块的时候，"谁能看见谁" 的边界全靠 cache 的内容来保证，掩码逻辑不会另外冒出来。
+
+## 先证对，再谈快
+
+加速如果改了输出，那它是 bug 不是优化。所以 stage02 把正确性放在第一位，而且是逐个生成长度验证。判据是 `maxLogitDrift`（两条路径最后一个 token 的 logits 向量的 L∞ 距离，即逐位取绝对差再取最大），以及生成的完整 token 序列是否一致：
+
+```
+[a] CORRECTNESS — cached path vs no-cache reference (must be exact):
+    gen= 8  maxLogitDrift=0.00e+0  ids_match=true
+    gen=16  maxLogitDrift=0.00e+0  ids_match=true
+    gen=32  maxLogitDrift=0.00e+0  ids_match=true
+    gen=64  maxLogitDrift=0.00e+0  ids_match=true
+    => EXACT at every length (cache is correct)
+```
+
+`0.00e+0`，每个长度都是。注意这里用的是 L∞（最大单点差）而不是均值，是故意的：一个被算崩的 logit（比如某个点乘溢出）足以翻转 argmax，而均值会把这种单点灾难平摊掉藏起来。能做到逐位精确零，是因为两条路径共用同一套注意力/FFN 算术核（`blockStep`），唯一的差别就是注意力看到的 K/V 从哪来——而那正是我们要研究的变量。
+
+为什么逐位精确零这么重要？因为后面第 7 章量化时，int8 路径**不会**是零漂移，而是一个有界的小漂移。只有当 KV 缓存这种"应该完全无损"的优化被钉死在零，你才有一把干净的尺子去衡量量化那种"有损但可接受"的优化漂了多少。
+
+## 加速比：越生成越值
+
+正确性锁死后，看 headline。stage02 给四个生成长度分别 wall-clock 两条路径的完整生成时间（prompt prefill + nGen decode）：
+
+```
+[b] SPEEDUP — no-cache total ms / cached total ms (grows with gen length):
+    gen  no-cache(ms)  cached(ms)   speedup
+      8       148.65      22.35   6.65x
+     16       302.48      21.74   13.92x
+     32       738.15      27.48   26.86x
+     64      1697.18      40.12   42.31x
+    => speedup grows monotonically with length — the O(n²)→O(n) fingerprint
+```
+
+读这张表的关键不是任何单个数字，而是**加速比单调上涨**这条趋势线。看缓存那一列：从 8 到 64 token，时间从 22.35ms 涨到 40.12ms，近乎线性。再看 no-cache 列：148.65 涨到 1697.18，超过 11 倍——序列翻了 8 倍，时间翻了 11 倍，这就是平方项在显形。两列一除，加速比从 6.65x 一路到 42.31x。
+
+这条上涨曲线本身就是"我们抹掉了一个 O(n) 因子"的指纹。如果缓存做对了但加速比是平的（不随长度涨），那说明你根本没去掉那个因子——很可能 cache 在偷偷重读历史，每步还是 O(n) 的活。第 1 章 metrics 模块那段注释专门点过这个反向诊断：inter-token latency 如果随 step index 稳步上升，你的"缓存"就是假的。
+
+一句必须说在前面的诚实话：这些绝对毫秒数是悲观的——配套模型是合成权重的玩具，kernel 是没优化的 float64 裸循环。能迁移到真实引擎的不是绝对值，是**加速比这个比值**和**它随长度变宽**这个形状。这是全书一以贯之的诚实约定（见 `src/core/metrics.ts` 头部三条规则）。
+
+## ✦ 工程师真正盯的是那本显存账
+
+到这儿初学者觉得 KV 缓存是个纯赚的优化——用一点内存换巨大加速。资深的人盯的是另一个数字：**KV cache 的显存账，常常比模型权重还大，它才是决定一张卡能塞多少并发请求的硬上限。**
+
+加速比是给 demo 看的；显存账是给容量规划看的，是真正卡住你 QPS 的东西。看 stage02 把它算出来（`estimateKVBytes` 是对 config 的精确算术，不是测量，所以标 `(est.)`）：
+
+```
+[c] MEMORY — KV cache grows linearly in sequence length (est.):
+    seq   1 seq        32 seqs
+     16    32.00 KiB     1.00 MiB (est.)
+     32    64.00 KiB     2.00 MiB (est.)
+     64   128.00 KiB     4.00 MiB (est.)
+    128   256.00 KiB     8.00 MiB (est.)
+    256   512.00 KiB    16.00 MiB (est.)
+    => +2.00 KiB/token/seq (est.); GQA already saves 2x vs MHA here
+```
+
+公式就在 `src/core/metrics.ts`，记住它你就能在白板上算容量：
+
+```ts
+export function estimateKVBytes(cfg: ModelConfig, seqLen: number, nSeqs: number): number {
+  const bytesPerFloat = 8; // float64 payload
+  const elemsPerLayer = 2 * cfg.nKVHeads * cfg.dHead * seqLen;  // 2 = K and V
+  return elemsPerLayer * cfg.nLayers * nSeqs * bytesPerFloat;
+}
+```
+
+`2 × nKVHeads × dHead × seqLen × nLayers × nSeqs × bytesPerFloat`。三个要点：
+
+1. **随 seqLen 线性**。每个 token 在这个玩具配置里加 2.00 KiB/seq；context 翻倍，cache 翻倍。这条线性增长，就是为什么长上下文是显存杀手。
+2. **随 nSeqs 线性**——也就是随并发数线性。32 路并发在 256 长度下要 16 MiB。把玩具数字换成真模型你就懂为什么 KV 缓存能比权重大：一个 70B 模型权重 fp16 约 140GB 是固定的，但服务 128 路、每路 8K context 的 KV 缓存能轻松吃掉几十上百 GB，而且它**随你想服务的并发量增长，权重不增长**。所以单卡能塞多少并发请求，瓶颈往往不是算力是 KV 显存。
+3. **`nKVHeads` 而不是 `nHeads`**。这是 GQA（Grouped-Query Attention，多个 query 头共享一组 K/V 头）省显存的位置。这个默认配置 `nKVHeads=2 / nHeads=4`，所以 GQA 已经比标准多头注意力（MHA）省了 `4/2 = 2x`，输出末尾那句 `GQA already saves 2x vs MHA here` 就是这么来的。
+
+把 KV 缓存理解成"拿显存换计算"，你就懂了后面三章在干什么：第 5 章 PagedAttention 省的是这本账的**碎片浪费**（像虚拟内存分页一样按块分配，不给每个序列预留满额连续显存），第 7 章量化省的是这本账的**每元素字节数**（公式里那个 `bytesPerFloat`：fp16 就比 float64 直接小 4 倍）。
+
+## 失败模式：跳过 prefill，模型在回答一段它没读过的 prompt
+
+KV 缓存最常见的真实 bug 不是算错，是**忘了在 decode 前把 prompt 灌进缓存**（或者重置了缓存又复用）。这个 bug 阴险在它不崩溃。stage02 专门复现它：
+
+```
+[d] FAILURE MODE — decoding without prefilling the cache (a real bug):
+    correct cache.len after prefill = 48 (saw the whole prompt)
+    buggy   cache.len               = 0 before decode (saw nothing)
+    maxLogitDrift correct-vs-buggy = 1.67e+0 (finite & large = silent wrong answer, not a crash)
+    argmax next token: correct=2 buggy=255 flipped=true
+    => the cache IS the context. Skip prefill and the model answers a prompt it never read.
+```
+
+复现代码就是同一个模型、同一个 token、同一条代码路径，只差缓存状态：
+
+```ts
+// correct: prefill THEN take the first decode step.
+const correctCache = newCache(DEFAULT_CONFIG);
+let correctLogits: Float64Array = new Float64Array(0);
+for (const id of promptIds) correctLogits = forwardStep(model, id, correctCache);
+const firstTok = argmax(correctLogits);
+const correctFirstStep = forwardStep(model, firstTok, correctCache);
+// buggy: SKIP prefill — decode the same first token into a fresh, empty cache.
+const buggyCache = newCache(DEFAULT_CONFIG);
+const buggyFirstStep = forwardStep(model, firstTok, buggyCache);
+```
+
+正确路径 prefill 后 `cache.len=48`（看过整段 48 token 的 prompt）；buggy 路径 `cache.len=0`（什么都没看过，注意力只对它自己一个 token，位置 0）。结果是 `maxLogitDrift=1.67`——**有限且大**，argmax 从 2 翻到 255。
+
+记住这个症状的形状：不是 NaN，不是栈溢出，不是异常。是一个**有限的、大的漂移**。这就是缓存一致性 bug 的签名。它在生产里表现为"模型答非所问"——你以为它在回答你的 prompt，它其实在对一段空历史自说自话。因为 **cache 就是 context**，缓存里没有 prompt，模型就真的没读过 prompt。
+
+这也解释了为什么第 1 章把"逐位证对"立成铁律：你没法靠肉眼看输出发现这类 bug——untrained 模型本来就吐 gibberish，1.67 的漂移在乱码里看不出来。只有 `maxLogitDrift` 这把尺子能在它翻转 argmax 之前抓到它。把这条经验带到 continuous batching：第 4 章拼 batch 时最容易犯的就是这类"某个序列的 cache 状态错位"，而它同样不崩溃、同样需要 drift 来抓。
+
+## ⚡ 前沿：这本显存账还在被各路人马围攻
+
+KV 缓存把 decode 从 O(n²) 砍到 O(n)，代价是那本随 batch × seq × layers × dKV 线性膨胀的显存账。**这本账目前没有通用最优解，是 2024 年以来推理优化最热的开放战场。** 几条主攻方向：
+
+- **GQA / MLA**：GQA 让多个 query 头共享 K/V 头（就是我们公式里 `nKVHeads < nHeads` 那一刀），已是开源模型标配。DeepSeek-V2/V3 的 MLA（Multi-head Latent Attention）更激进，把 KV 压成一个低秩潜向量再存，等于在公式里把 `nKVHeads × dHead` 换成一个小得多的潜维度。这俩动的是公式的**头维度项**。
+- **KV cache 压缩 / 驱逐**：H2O、StreamingLLM 这类方法赌的是"不是所有历史 token 都同等重要"——驱逐掉注意力权重低的旧 token，只保留少数"重 hitter"加上开头几个 attention sink。这动的是公式的 **seqLen 项**：不让它真的随上下文无限涨。
+- **量化**：把 KV 从 fp16 降到 int8/int4，动的是 `bytesPerFloat` 项，第 7 章会动手做。
+
+注意这三条攻的是公式里的不同因子，可以叠加，但每条都在拿质量换显存——压多了模型就开始"忘事"或答歪。压缩率和质量损失之间没有放之四海的甜点，跟模型、跟任务、跟上下文长度都强相关，**至今没有一个通用解**。哪种组合在你的负载上划算，目前还得靠实测，而你手上现在就有了那把尺子（`maxLogitDrift` / `perplexity`）去量它漂了多少。
+
+---
+
+下一章（第 3 章）我们离开"对不对"，进入"怎么选"——采样：贪心、temperature、top-k/top-p，以及它们各自怎么坏。本章一直用 `argmax` 贪心解码是为了让两条路径的 token 流可比；真实服务里你几乎不会用纯贪心。

--- a/src/content/library/llm-inference/03-采样策略.md
+++ b/src/content/library/llm-inference/03-采样策略.md
@@ -1,0 +1,255 @@
+---
+title: "采样策略：从 logits 到下一个 token，温度/top-k/top-p 的取舍"
+slug: "03"
+collection: "llm-inference"
+order: 3
+summary: "第 01-02 章把一行 token 喂进模型、用 KV cache 把每步 forward 摊薄，得到的产物只有一样：一行覆盖整个词表的 logits。这章接手那行 logits，把它变成下一个 token——实现 greedy / temperature / top-k / top-p / repetition penalty，并用熵和候选集大小量化每个旋钮到底改了分布的哪一部分。诚实点先说清楚：采样必须用种子化 PRNG 才能复现，否则后面第 06 章的投机解码、第 08 章的 benchmark 全部失去基线；而它又跑在 decode 热路径上每步都执行，所以实现效率也得进吞吐账。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+前两章的产物，归根结底只有一行数字：一个长度等于词表大小的 `Float64Array`，叫 logits（模型对每个候选 token 打的原始分数，未归一化）。第 01 章手写了 forward 把它算出来，第 02 章用 KV cache 让每生成一个 token 只重算最后一列。但模型本身不会"选词"——它吐出一行打分就停了。**从这行 logits 里挑出下一个 token，是推理引擎暴露给用户的最大一个行为旋钮，没有之一。** 同一套权重，greedy 解码出来是流水账，temperature 调到 1.2 就开始天马行空,这中间模型一个浮点数都没变,变的全在采样器里。
+
+更要命的是它的位置:采样发生在 decode 热路径上,每生成一个 token 跑一次,生成到天荒地老。所以它有两副面孔——一副是"行为旋钮",决定输出长什么样;一副是"热路径代码",它的实现效率直接进吞吐账。这章两副面孔都要量化,不靠玄学("温度高=更有创意"这种话本章不接受),靠熵(分布有多分散的标准度量)和候选集大小这两个能打印出来的数。
+
+配套代码是单文件 `examples/llm-inference-from-scratch/src/stage03-sampling.ts`,它复用第 01-02 章已经写好的 `core/`(softmax、mulberry32、模型 + forwardStep、metrics),自己只加采样器原语。下面所有数字都来自这个文件跑出来的真实输出,合成 logit 行会明确标注。
+
+## 一、为什么采样器必须是 `(logits, params, rng) → token` 的纯函数
+
+先把架构底座钉死,因为它决定了后面所有实验能不能做。`stage03-sampling.ts` 里每个采样器都长这个样子:接收一行 logits、一组参数、一个随机数发生器,返回一个 token id,**没有任何全局状态**。
+
+```ts
+// 从分布里抽一个下标:inverse-CDF(走累积和直到超过 u)。
+// 末位 fallback 防的是浮点舍入让累积和停在 0.9999999 < u 的退化情况。
+function sampleFromDist(probs: Float64Array, rng: () => number): number {
+  const u = rng();
+  let cum = 0;
+  for (let i = 0; i < probs.length; i++) {
+    cum += probs[i];
+    if (u < cum) return i;
+  }
+  return probs.length - 1; // fp 舍入兜底;mass 本应已经 ~1
+}
+```
+
+为什么强调"纯函数 + 注入 rng"?因为**可复现性是这本书的地基,一旦破功,后面全塌**。第 06 章的投机解码要对比"小模型草稿 vs 大模型验证"必须同种子;第 08 章的 benchmark 要复现一条 tok/s 曲线也必须同种子。如果采样器内部偷偷调了 `Math.random()`,那"同样的输入跑两次结果不同",你就再也没法判断一个性能差异是优化带来的还是随机噪声带来的。
+
+这不是抽象担忧。`(a)` 实验直接把它证出来,不是嘴上说说:
+
+```
+--- (a) 可复现性:同 seed 下每种策略重复运行结果一致 ---
+  temperature(T=1.0)   5 次 -> [5, 5, 5, 5, 5]  identical=true
+  top-k(k=3)           5 次 -> [1, 1, 1, 1, 1]  identical=true
+  top-p(p=0.9)         5 次 -> [4, 4, 4, 4, 4]  identical=true
+  greedy(T=0)          5 次 -> [0, 0, 0, 0, 0]  identical=true
+  控制对照 top-1 sampler 跨 6 个不同 seed -> [5, 6, 6, 9, 6, 4]
+```
+
+每种策略用**同一个种子** `mulberry32(42)` 重跑 5 次,token 序列逐位相同(`identical=true`)。关键在实现细节:每次跑都 `mulberry32(SEED)` 重新建一个 PRNG,重置随机流,所以第 r 次跑看到的 `u` 抽样跟第 1 次完全一样。
+
+但光证"同种子相同"不够——一个**永远返回 argmax 的退化采样器**也满足"同种子相同"。所以下面那行控制对照是另一半证明:跨 6 个**不同**种子,采到的 token 是 `[5, 6, 6, 9, 6, 4]`,确实在变。两边合起来才是个双向证明:同种子锁死、异种子有变化,这才叫"种子化随机"而不是"伪装的 greedy"。
+
+> 这里有个坑值得标注:做这个对照用的不能是尖分布。如果用 SHARP 行(下面会讲),T=1 时 ~0.99 的概率压在 tok0 上,每个种子都会落到 tok0,对照看起来就跟 greedy 一样,证明不了任何东西。代码里特意用 FLAT 行 + T=1.2,分布够散,不同种子才会真的分叉。**N=1 的"看起来对"是假信号,跨样本的分叉才是真信号**——这是贯穿全书的方法论。
+
+## 二、温度:缩放整体熵
+
+温度 T 是最先该理解的旋钮,因为它改的是分布的**全局形状**。做法极简单:softmax 之前把 logits 整体除以 T。
+
+```ts
+function softmaxWithTemperature(logits: Float64Array, temperature: number): Float64Array {
+  if (temperature <= 0) {
+    // Greedy 极限:argmax 上的 one-hot。显式这么写(而不是 softmax(z/0) -> NaN)
+    // 正是 T=0 能"直接当确定性 greedy 用"的原因。
+    const out = new Float64Array(logits.length);
+    out[argmax(logits)] = 1;
+    return out;
+  }
+  const scaled = new Float64Array(logits.length);
+  for (let i = 0; i < logits.length; i++) scaled[i] = logits[i] / temperature;
+  return softmax(tensor(scaled, [1, scaled.length])).data;
+}
+```
+
+### 失败模式先行:T=0 不是"除以零"
+
+注意第一个分支。`softmax(z / T)` 里如果 T=0,你得到 `z / 0 = Infinity`,softmax 一进 `exp(Infinity)` 就 NaN,整个分布烂掉。**这是天真写法"就这么除"踩的第一个雷。** 正确做法是把 T≤0 当作 greedy 的极限单独处理:把全部概率压在 argmax 上的 one-hot。这么写 T=0 才"恰好就是确定性 greedy",不用调用方在外面再包一层判断。
+
+设计上为什么不用一个极小的 T(比如 1e-9)去逼近?因为那是在用浮点精度赌博——分布会变成数值上极不稳定的近似 one-hot,而且仍然走采样抽签那条路,徒增开销。直接特判,既正确又省。
+
+### 量化:T 升,熵单调升
+
+"温度高=更多样"这话只有量出来才可信。`(b)` 实验用一行合成的 SHARP logits(一个明显赢家),扫 T 看熵(单位 bit):
+
+```
+--- (b) 温度 T ↑ ⇒ 分布熵 ↑(多样性单调上升),熵单位 bit ---
+    (SHARP 合成行,vocab=10,均匀分布上界 = log2(10) = 3.322 bit)
+  T=0.0  entropy=0.000 bit   argmax=tok0 p(argmax)=1.000
+  T=0.5  entropy=0.000 bit   argmax=tok0 p(argmax)=1.000
+  T=1.0  entropy=0.077 bit   argmax=tok0 p(argmax)=0.993
+  T=1.5  entropy=0.533 bit   argmax=tok0 p(argmax)=0.935
+  熵随 T 单调非降 = true(T=0 为 one-hot 下界 0 bit)
+```
+
+读这张表的几个要点:
+
+- **熵的物理意义是边界清楚的标量**:0 bit = one-hot(完全确定),`log2(词表大小)` = 均匀分布(完全随机)。这里词表 10,上界 3.322 bit。你的输出"确定性 vs 多样性"就在这条 0→3.322 的轴上滑动。
+- **T=0.5 仍然是 0.000 bit**:温度小于 1 是在锐化,SHARP 行本来就尖,锐化到打印精度内已经是 one-hot 了。这告诉你:对一个已经很自信的分布,降温几乎没意义,它早就 all-in 在 argmax 上了。
+- **熵单调非降**(`= true`)。这是温度这个旋钮的核心不变量:你拧大 T,熵不会反而变小。
+
+为什么不直接看生成的文本判断"多样不多样"?因为这个项目的权重是 toy 的(为了能在没有 GPU 的笔记本上跑完整本书),生成出来的是胡言乱语,**肉眼看不出好坏**。熵是模型无关的度量:不管权重是 toy 还是 Llama,T 升熵升这条规律一样成立。用熵,你拿掉了"权重质量"这个干扰变量,单独测采样器的行为。
+
+## 三、top-k vs top-p:✦ 它俩的失败场景正好相反
+
+到这里是本章最该记住的判断。新手常把 top-p(nucleus sampling,核采样)当成"更高级的 top-k",这是错的——**它俩不是高低级关系,是两种正交的截断策略,失败场景恰好互补,选错旋钮比不调还糟。**
+
+先看实现差在哪。top-k 砍尾巴用的是**固定数量**:
+
+```ts
+function topKDist(probs: Float64Array, k: number): { dist: Float64Array; kept: number } {
+  const idx = Array.from(probs.keys()).sort((a, b) => probs[b] - probs[a]);
+  const keep = Math.min(k, probs.length);  // 永远保留 k 个,跟分布形状无关
+  // ... 在这 k 个上重新归一化,其余清零
+  return { dist: out, kept: keep };
+}
+```
+
+top-p 砍尾巴用的是**自适应数量**——保留累积概率刚好够到 p 的最小集合:
+
+```ts
+function topPDist(probs: Float64Array, p: number): { dist: Float64Array; kept: number } {
+  const idx = Array.from(probs.keys()).sort((a, b) => probs[b] - probs[a]);
+  let cum = 0, kept = 0;
+  for (let i = 0; i < idx.length; i++) {
+    out[idx[i]] = probs[idx[i]];
+    cum += probs[idx[i]];
+    kept++;
+    // >= 意味着跨过阈值的那个 token 也保留——nucleus 采样保留边界 token,不丢。
+    if (cum >= p) break;  // 候选数据相关:尖分布很快够,平分布要很多个
+  }
+  // ... 归一化
+  return { dist: out, kept };
+}
+```
+
+候选数恒定 vs 候选数随分布变,这一个差异就是全部分叉的根源。`(c)` 实验把它打印出来,用同样的 k=5、p=0.9 跑在尖、平两种分布上:
+
+```
+--- (c) 同一 logits 下 top-k vs top-p 实际候选集大小对比 ---
+  SHARP (entropy=0.077 bit)  top-k(k=5) 候选=5   top-p(p=0.9) 候选=1
+  FLAT  (entropy=3.305 bit)  top-k(k=5) 候选=5   top-p(p=0.9) 候选=9
+```
+
+把两边的失败模式说透:
+
+**分布很尖时(SHARP,熵 0.077 bit),top-k 是凶器。** 模型已经 99% 确定该选 tok0 了,top-k(k=5) 还是硬塞 5 个候选进采样池——后面那 4 个是模型几乎不信的噪声 token,你给了它们被抽中的机会。而 top-p(p=0.9) 这时只保留 1 个候选,因为 tok0 一个就盖过了 0.9。**尖分布场景:top-k 引噪声,top-p 自动收紧。**
+
+**分布很平时(FLAT,熵 3.305 bit,接近 3.322 的均匀上界),top-p 是凶器。** 模型很不确定,概率摊得很匀,top-p(p=0.9) 为了凑够 0.9 的累积质量,把 9 个 token 全放进来了——几乎不截断,等于没设防。而 top-k(k=5) 这时还老老实实只留 5 个,反而提供了真正的约束。**平分布场景:top-p 放进一大堆,top-k 自动收紧。**
+
+这就是"失败场景正好相反"的精确含义。它直接给出选型规则:
+
+- 你的任务**期望分布通常很尖**(事实问答、代码、确定性指令)→ 用 top-p,它在自信时自动收紧,不会画蛇添足放噪声。
+- 你的任务**期望分布通常很平**(开放创作、头脑风暴)→ top-p 在这里会失控,top-k 给的固定上限反而是更可靠的护栏。
+- 生产里两者常叠加(先 top-k 砍掉绝对长尾,再 top-p 自适应),正是因为单用任一个都有它崩的那一侧。
+
+记住这个判断的代价是:**选错旋钮比不调还糟**——你以为加了约束,实际上在你最需要约束的那一侧它恰好失效了。
+
+## 四、采样在 decode 热路径上的真实开销
+
+行为讲完,回到第二副面孔:采样器跑在每生成一个 token 都执行的热路径上,它的实现效率进吞吐账吗?直觉上 sort 一遍词表(top-k/top-p 都要排序)听起来不便宜,词表动辄几万。
+
+`(d)` 实验是本章唯一用**真实模型 + forwardStep 解码热路径**实测 wall-clock 的部分(前面 a/b/c/e 都是合成 logit 行)。它对每种采样器跑 64 步真实 decode,把 forward 的耗时和采样器单独的耗时分开计:
+
+```
+--- (d) 采样在 decode 热路径的 per-step 开销实测(真实 wall-clock)---
+  greedy               forward ITL mean=0.384ms p95=0.411ms  2603.1 tok/s | sampler alone=0.0003ms/tok (~0.07% of step)
+  temperature(T=1.0)   forward ITL mean=0.389ms p95=0.412ms  2569.4 tok/s | sampler alone=0.0032ms/tok (~0.81% of step)
+  top-k(k=40)          forward ITL mean=0.423ms p95=0.446ms  2365.3 tok/s | sampler alone=0.0305ms/tok (~6.73% of step)
+  top-p(p=0.9)         forward ITL mean=0.388ms p95=0.413ms  2576.9 tok/s | sampler alone=0.0308ms/tok (~7.35% of step)
+```
+
+读法分两层:
+
+**第一层,绝对数。** 采样器单独耗时从 greedy 的 0.0003ms 到 top-k 的 0.0305ms,确实差了百倍——sort 不是免费的。top-k 和 top-p 都要排序词表,所以它俩(0.0305 / 0.0308ms)明显比 greedy(只 argmax 一遍)和 temperature(只 softmax,不排序)贵。这符合实现直觉。
+
+**第二层,相对数,这才是该带走的结论。** 采样器占整步的比例:greedy 0.07%,temperature 0.81%,top-k 6.73%,top-p 7.35%。**即使最贵的 top-p,采样也只占一步的 7% 出头,九成以上时间在 forward 上。** 换句话说,decode 慢,锅几乎全在前向传播(那才是搬动几 GB 权重过显存带宽的活,见第 02 章的 KV cache 和后面第 07 章的量化),不在采样器。
+
+这里必须诚实标注 toy 的局限:`ITL mean=0.384ms`、`2603 tok/s` 这些**绝对值偏乐观**,因为 toy 模型用的是 float64 纯 JS kernel,没有真实大模型那种巨大的 GEMM(矩阵乘)。真实引擎上单步 forward 是几十毫秒量级,绝对 tok/s 比这低一两个数量级。但**可迁移的是相对结论**:不管 forward 慢到什么程度,采样占比只会更小(因为采样开销是固定的、跟 forward 一起被拉大的分母),"采样在热路径里占比极小"这条在真机上更成立。
+
+工程推论很直接:**别把优化预算砸在采样器上**。你想提吞吐,去抠 forward、抠 KV cache 排布、抠批处理(第 04 章 continuous batching),不是去给 top-p 的 sort 写个 SIMD 版本——那是优化了占比 7% 里的一小块。当然反过来也成立:如果哪天你的采样器实现烂到占了 30%,那一定是写出了 bug(比如每步重复全量 sort 没复用),那才该查。
+
+## 五、两个把输出搞坏的失败模式
+
+把旋钮交给用户,就得讲清楚它们怎么被拧坏。`(e)` 给两个具体失败模式,都是合成行精确触发的。
+
+### e1:top-p=1.0 + 温度过高 ⇒ 模型偏好被彻底抹平
+
+top-p=1.0 等于不截断(累积到 1.0 才停,等于全留)。这时温度就成了唯一的闸,温度拧太高,分布被压平到接近均匀,模型学到的偏好全没了:
+
+```
+  [e1] top-p=1.0 + 温度过高 ⇒ 近均匀采样(模型偏好被抹平)
+       T=1.0 top-p=1.0  entropy=0.077 bit (= 2.3% of uniform 3.322)
+       T=5.0 top-p=1.0  entropy=3.018 bit (= 90.9% of uniform 3.322)
+       T=50.0 top-p=1.0  entropy=3.320 bit (= 99.9% of uniform 3.322)
+       T=50 跨 8 seed 采样 -> [6, 7, 7, 9, 6, 5, 0, 1]
+```
+
+T=1 时熵只占均匀上界的 2.3%(模型很自信),T=5 已经到 90.9%,T=50 时 99.9%——分布**几乎就是均匀分布了**。下面那行 draws 是实锤:T=50 跨 8 个种子采样得到 `[6, 7, 7, 9, 6, 5, 0, 1]`,本来强势的 tok0 不再主导,你在**掷一个 10 面骰子**,模型那行 logits 白算了。
+
+这就是为什么生产里温度通常卡在 [0, 2] 这个区间。高于 2 不是"更有创意",是"逐渐丢弃模型"。"创意"和"胡乱"之间没有提示,只有熵在悄悄爬向上界。
+
+### e2:repetition penalty 过大 ⇒ 把正确 token 一起压没
+
+重复惩罚(repetition penalty)是对付模型复读机的钝器:对已出现过的 token,正 logit 除以 penalty(压低),负 logit 乘以 penalty。
+
+```ts
+function applyRepetitionPenalty(logits, seen, penalty) {
+  const out = Float64Array.from(logits);
+  for (const id of seen) {
+    // 正负不对称是标准 CTRL/HF 写法:除一个正 logit 是压低,
+    // 但除一个负 logit 会把它推向 0(抬高),方向反了——所以负的改成乘。
+    out[id] = out[id] > 0 ? out[id] / penalty : out[id] * penalty;
+  }
+  return out;
+}
+```
+
+失败模式是:penalty 太大,会把一个**合法地需要重复**的正确 token 也压到次优 token 之下:
+
+```
+  [e2] repetition penalty 过大 ⇒ 把正确 token 也压没
+       penalty=1.0  logit[tok0] 6.00 -> 6.00  argmax 0 -> 0  OK
+       penalty=1.2  logit[tok0] 6.00 -> 5.00  argmax 0 -> 0  OK
+       penalty=10.0  logit[tok0] 6.00 -> 0.60  argmax 0 -> 1  ⚠ 正确 token 被压没
+```
+
+这行合成数据里 tok0 是正确答案(logit 6.0)且已经出现过,tok1 是逼近的次席(logit 5.0)。penalty=1.2 把 tok0 压到 5.0,还压得住,argmax 仍是 0;penalty=10 把它压到 0.6,**argmax 翻车到 tok1**,正确答案被牺牲了。
+
+为什么这是"钝器"?因为它一刀切——它惩罚的是"出现过",不分青红皂白。可中文里"的的""了了"该压,但代码里 `for (let i = 0; i < n; i++)` 那些必然重复的结构 token、英文里 "the" "is" 这种高频功能词,它一样压。penalty 调大一点,先坏的往往是这些合法重复。所以实践是:轻度(1.1~1.3)抑制无害,往上每加一点都在拿正确性换"不复读",得盯着输出调。这也解释了为什么后来出现了更精细的变体(frequency/presence penalty 按出现次数线性加,而不是这种乘除一刀切),但那不在本章 scope。
+
+## 六、⚡ 前沿:把采样从"选 token"升级成"在合法集合里选 token"
+
+本章实现的所有旋钮,都在做同一件事的变体:**在整个词表上调整一个概率分布,然后抽一个**。temperature 缩放它、top-k/top-p 截断它、penalty 改写它——但抽样的候选空间始终是"整个词表"。
+
+2024-2025 的约束/结构化解码(constrained/structured decoding)把这个前提改了。当你要模型输出**严格合法的 JSON、符合某个 schema、或匹配一个语法(grammar)**,问题就从"挑个概率高的 token"变成了"在当前状态下哪些 token 是**语法上合法**的,只在这些里挑"。
+
+机制上,像 outlines、XGrammar 这类工具的做法是:把目标格式(JSON schema / 正则 / BNF 语法)编译成一个有限状态机(FSM,记录"现在解析到哪、接下来允许哪些字符"),然后在每一步采样前,**用 FSM 算出一个 mask**——把所有当前非法的 token 的 logit 直接打成 `-Infinity`,再走我们这章的 temperature/top-p 那套。效果是模型**物理上不可能**生成出格式错误的输出,而不是"提示它请输出 JSON 然后祈祷"。
+
+放进本章的框架看,它就是在 `softmaxWithTemperature` 之前多插一层 `applyGrammarMask(logits, fsmState)`——和 `applyRepetitionPenalty` 同一个位置(改 logits),只是它改的不是"重复",是"合法性"。区别在它带状态:FSM 要随每个采出的 token 推进,这又和第 02 章的 KV cache 一样,是另一处"每步都得维护的解码状态"。
+
+**为什么标⚡:这里没有通用的免费午餐,仍在活跃研究。** 几个真问题没有定论:(1) FSM 编译和每步 mask 计算本身有开销,复杂 schema 下可能把我们 `(d)` 测出来的"采样占比 7%"这个舒服结论顶破——把 mask 摊进热路径后开销分摊怎么做,各家方案差异很大;(2) 强行 mask 会扭曲分布,被 mask 掉的概率质量重新分配到合法 token 上,这对生成质量的影响(模型"想说"的被堵住了)还没有公认的度量;(3) 和投机解码(第 06 章)、连续批处理(第 04 章)的组合——每个请求的 FSM 状态不同,如何在一个 batch 里高效地做 per-request mask,是当前工程上最硬的一块。这是个明确"正在研究、无通用解"的方向,你现在能做的是理解它的位置:它不是新采样器,是采样器前面那一层会动的"合法性闸门"。
+
+## 小结与接续
+
+这章把第 01-02 章产出的那行 logits 变成了 token,留下几个该带走的判断:
+
+1. **采样器是 `(logits, params, rng)` 纯函数,rng 必须种子化**——可复现性是全书地基,`(a)` 用"同种子锁死 + 异种子分叉"双向证明了它(`[5,5,5,5,5]` vs 跨种子 `[5,6,6,9,6,4]`)。
+2. **每个旋钮改分布的不同部分**:温度缩放整体熵(T 升熵单调升,`(b)`)、top-k 固定截断、top-p 自适应截断、penalty 改写已出现 token。
+3. **✦ top-p 不是更高级的 top-k,失败场景相反**:尖分布时 top-k 引噪声 / top-p 收紧(候选 5 vs 1),平分布时 top-p 失控 / top-k 收紧(候选 9 vs 5)——选错旋钮比不调还糟。
+4. **采样不进吞吐瓶颈**:`(d)` 实测最贵的 top-p 也只占一步 7.35%,优化预算该砸 forward 不是采样器(toy 绝对值乐观,相对结论可迁移)。
+5. **旋钮会反噬**:温度过高把模型抹成均匀骰子(`(e1)` T=50 占均匀 99.9%),penalty 过大把正确 token 压没(`(e2)` penalty=10 argmax 0→1)。
+6. **⚡ 约束解码**把采样升级成"在合法集合里选",是采样器前的一层有状态闸门,开销摊销/质量扭曲/批处理组合都还没通用解。
+
+接下来:第 04 章 continuous batching 会把这章的单序列采样器推广到一个 batch 里多个请求各自有自己的采样参数和(下一章会暴露的)各自的进度;第 06 章投机解码会回过头来重度依赖本章证明的可复现性,因为它要逐 token 比对草稿模型和验证模型——没有种子化采样,那个比对根本没法做。

--- a/src/content/library/llm-inference/04-连续批处理.md
+++ b/src/content/library/llm-inference/04-连续批处理.md
@@ -1,0 +1,209 @@
+---
+title: "连续批处理：让 GPU 不空转，把吞吐榨干"
+slug: "04"
+collection: "llm-inference"
+order: 4
+summary: "第 02 章把 KV cache 装进了单请求 decode，第 03 章让采样可控；但单请求 decode 是访存密集型——算力大半时间在等显存，吞吐靠并发请求填满才上得去。这章先实现静态批暴露队头阻塞，再用连续批处理把推理引擎从『一个函数』升级成『一个调度器』，这是 vLLM/TGI 吞吐神话的真正引擎。下一章 05 解决并发请求带来的 KV 显存碎片。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+判断一个 serving 系统好不好，我先问一句：它怎么处理"长度方差"？真实流量里，一个请求回个"好的"，另一个要写两千字报告——生成长度差几十倍是常态，不是异常。这一个数字，决定了你的 GPU 是满载还是大半时间在等最慢那条请求。我们这章拿一组真实差 10 倍的负载（生成长度 `[4, 40, 8, 32, 6, 36, 5, 30]`，min=4 max=40 mean=20.1）把两种调度策略放一起跑，实测对照。结论先放这：静态批的吞吐会被最长那条请求锁死，连续批是唯一解。
+
+这章和前面三章的关系：第 02 章给了单请求的 KV cache（让 decode 不必重算历史），第 03 章给了采样（greedy/temperature/top-p）。它们合起来构成"一次推理 = 一个 forward 函数"。但一个函数喂不饱 GPU。这章把它升级成调度器——决定"哪些请求这一步一起算"。配套代码在 `examples/llm-inference-from-scratch/src/stage04-continuous-batch.ts`，下面所有数字都是它的真实运行输出。
+
+## 为什么单请求 decode 喂不饱 GPU
+
+先讲清楚动机，否则后面所有调度都是空中楼阁。
+
+LLM 推理分两个阶段。**prefill**（预填充，把整段 prompt 一次性算出 KV）是算力密集——一次大矩阵乘吃满 GPU。**decode**（逐 token 生成）是另一回事：每步只算一个新 token，要把整个模型权重从显存搬一遍，只为做一次极瘦的矩阵-向量乘。这叫**访存密集**（memory-bound，瓶颈是搬数据不是算数据）。算力单元（GPU 上的 Tensor Core）大半时间在等显存把权重喂过来。
+
+这不是实现没优化，是 decode 的物理决定的：batch=1 时，权重搬运成本被一个 token 摊销，算术强度（每字节数据做多少次浮点运算）低得可怜。补救只有一条路——**让多个请求共享这一次权重搬运**。同一份权重搬进来，顺手把 N 个请求的 token 都算了，搬运成本被 N 个 token 摊薄。这就是 batching 的全部理由：不是为了"省事一起处理"，是为了把访存密集的 decode 拽向算力密集，让闲着的算力派上用场。
+
+所以问题从来不是"要不要 batch"，而是"怎么 batch"。下面两种答法，差距是 1.57 倍。
+
+## 静态批：能跑，但被最长请求锁死
+
+最朴素的做法：攒一批 N 个请求，padding 到同长（短的补占位），一起开跑，整批必须等到**最长**那条生成完才释放，再攒下一批。代码里 `runStatic` 就这逻辑：
+
+```ts
+// examples/llm-inference-from-scratch/src/stage04-continuous-batch.ts
+while (queue.length > 0) {
+  // form one static batch
+  const batch: (Slot | null)[] = [];
+  while (batch.length < capacity && queue.length > 0) {
+    batch.push(admit(queue.shift()!));
+  }
+  // run until ALL slots in this batch are finished
+  let anyActive = true;
+  while (anyActive) {
+    // ... decodeOneStep(slot) for live slots, padStep() for finished ones
+  }
+}
+```
+
+注意 `run until ALL slots in this batch are finished`——这一句是病根。短请求早早算完了，但它占的 slot（批里的一个位置）不释放，原地空转到全批结束。
+
+### 队头阻塞：一个长请求绑架一整批
+
+这就是**队头阻塞**（head-of-line blocking，排在前面的慢请求堵住后面所有请求）。看实测的每请求完成延迟（单位是调度 step，所有请求都在 t=0 到达，所以延迟里包含排队等待）：
+
+```
+request ids       : [ R0,  R1,  R2,  R3,  R4,  R5,  R6,  R7]
+request genLens   : [  4,  40,   8,  32,   6,  36,   5,  30]
+static latency    : [  4,  40,   8,  32,  46,  76,  45,  70]
+continuous latency: [  4,  40,   8,  32,  10,  44,  15,  45]
+```
+
+batch 容量是 4，所以 R0..R3 是第一批，R4..R7 是第二批。盯住 **R4**：它只要生成 6 个 token，本该是个秒回的短请求。但它排在第二批，必须等第一批彻底排空——第一批里有 R1（genLen=40）。结果 R4 在静态批里第 **46** step 才完成（40 步等第一批 + 6 步自己），而它真正干活只要 6 步。一个 6-token 请求的完成延迟被拖到了批内最长请求的量级。
+
+汇总成尾延迟（tail latency，慢请求的延迟，用户实际体感的卡顿）：
+
+```
+static     p50=45 p99=76 max=76 steps
+continuous p50=32 p99=45 max=45 steps
+```
+
+静态批的 p99 是 76，被那条 40-token 的请求死死锁住。**这就是我开头说的"吞吐被最长那条锁死"——不是吞吐数字的玄学，是调度结构的必然。**
+
+### 空转的浪费：被 padStep 诚实建模出来
+
+光看延迟还不够，得看 GPU 到底浪费了多少。看静态批的 batch 占用轨迹（`··` = 该 slot 已算完但被占住空转）：
+
+```
+step   0 [R0 R1 R2 R3] active=4/4
+step   4 [·· R1 R2 R3] active=3/4
+step   8 [·· R1 ·· R3] active=2/4
+...
+step  23 [·· R1 ·· R3] active=2/4
+```
+
+R0 在第 4 步就完事了（genLen=4），但它的列从此变成 `··` 一路占到底。从第 8 步起整批只剩 2 个活跃 slot，却还在按 4 个 slot 的成本跑。
+
+这里有个建模细节值得停一下，否则数字会撒谎。在真 GPU 上，一步是对**整个 batch 宽度**做一次矩阵乘——一个请求已经完成的 slot 不是"免费跳过"的，除非你上 ragged/变长 kernel（这恰恰是连续批要买的复杂度），否则死 slot 被 padding 填上，它的那几行照样流过每个矩阵乘。代码用 `padStep()` 老实地烧掉一次真实的 forward pass 来复现这笔成本：
+
+```ts
+// padStep — the WASTE of a static batch, modeled honestly.
+function padStep(): void {
+  // ... reset scratch near maxSeq ...
+  forwardStep(model, 0, scratchCache); // real compute, discarded — the padding cost
+}
+```
+
+**为什么非要这么写**：toy 模型是标量 kernel，如果让它"聪明地"跳过死 slot，静态批和连续批的 wall-clock 会假装相等——速度差会退化成纯粹的 step 计数差，骗人。padStep 烧掉真实算力，才让最终的 wall-clock 加速比是诚实的，不是计数把戏。
+
+## 连续批处理：以 token 为粒度调度
+
+连续批（continuous / in-flight batching，Orca 论文提出、vLLM/TGI 落地）的核心认知转换一句话：**调度单位不是"一整批"，是"一个 decode step"**。每一步结束，算完的序列立刻离场释放 slot，等待队列里的新请求**立刻**补位（backfill）。于是每一步 batch 都尽量填满，短请求一算完就走，绝不被长请求绑架。
+
+代码里 `runContinuous` 的 evict + backfill 是全章的题眼：
+
+```ts
+// evict finished, backfill from queue — the continuous part.
+for (let s = 0; s < capacity; s++) {
+  const slot = slots[s];
+  if (slot && slot.produced.length >= slot.req.genLen) {
+    completionStep.set(slot.req.id, globalStep + 1);
+    tokensByReq.set(slot.req.id, slot.produced);
+    // admit the next queued request into this freed slot THIS same step.
+    slots[s] = queue.length > 0 ? admit(queue.shift()!) : null;
+  }
+}
+```
+
+`admit the next queued request into this freed slot THIS same step`——同一步内补位，slot 不空一步。看连续批的占用轨迹，slot 列在 step 间换人：
+
+```
+step   3 [R0 R1 R2 R3] active=4/4
+step   4 [R4 R1 R2 R3] active=4/4   <- R0 完事(genLen=4), R4 立即补进 slot 0
+step   8 [R4 R1 R5 R3] active=4/4   <- R2 完事(genLen=8), R5 补进 slot 2
+step  10 [R6 R1 R5 R3] active=4/4   <- R4 完事, R6 补进
+step  15 [R7 R1 R5 R3] active=4/4   <- R6 完事, R7 补进
+```
+
+slot 0 这一列依次跑过 R0 → R4 → R6 → R7，四个请求接力共用一个位置。对照静态批同一列从头到尾 `R0` 然后 `··`——这就是 backfill 生效与否的肉眼区别。
+
+### 利用率换吞吐：实测 1.57 倍
+
+把这套接力翻译成吞吐和利用率（real wall-clock，performance.now 计时）：
+
+```
+static     : 161 tok in 201.3 ms over 76 steps
+             throughput = 800.0 tok/s   利用率 = 53.0% (busy 161/304 slot-steps)
+continuous : 161 tok in 128.4 ms over 45 steps
+             throughput = 1253.9 tok/s   利用率 = 89.4% (busy 161/180 slot-steps)
+speedup (continuous / static) = 1.57x wall-clock, 1.57x tok/s
+```
+
+同样产出 161 个 token，静态批跑了 76 步、利用率 53%；连续批 45 步、利用率 89.4%；wall-clock 快 1.57 倍。利用率这里指**算子有效占用率**——每步真正在算的 active slot 数除以容量，在真 GPU 上正比于 GPU 利用率（padding 出来的空 slot 要么浪费算力，要么靠 ragged kernel 省掉）。
+
+**诚实标注**：绝对的 800/1254 tok/s 偏悲观——模型是 toy（synthetic 权重 + float64 标量 kernel），不是真 GPU。可迁移的不是绝对值，是**比值**：连续批 vs 静态批的利用率差（53% → 89%）、加速比（1.57x）、短请求 p99 的改善（76 → 45）。这些比值在真实引擎上同样成立——这也是为什么 vLLM 当年那篇博客敢喊数量级吞吐提升。
+
+### 不变量：调度只改编排，不改单序列数学
+
+这里有条 load-bearing（承重的，少了整章就塌）的断言必须钉死：**两种策略对同一个请求，产出 bit-for-bit 完全相同的 token 序列**。调度只改"谁和谁同一步算"，绝不能改任何单个序列的数学。否则任何吞吐数字都是耍流氓——你拿"换了答案"换吞吐，那不叫优化，叫 bug。
+
+代码用逐位相等 + maxDrift 双重验证：
+
+```
+[0] 不变量 — 调度不改单序列数学 (per-request token equivalence):
+    所有 8 个请求: static 与 continuous 产出 token 序列逐位相等 = true
+    token-id maxDrift = 0.00e+0 (0 => 调度纯粹是编排, 数学不变)
+```
+
+`maxDrift = 0` 是这章可以放心谈吞吐的前提。这条不变量在真实引擎里同样是红线：连续批 backfill 时，新请求的 KV 必须正确地放进它自己的上下文里，绝不能让"同一步算"变成"互相串扰"——第 05 章 paged KV 的隔离设计，本质就是在保护这条不变量。
+
+## 失败模式：调度器必须算两笔账
+
+把推理引擎升级成调度器，就接管了两笔以前不用操心的账。算错任何一笔，系统要么延迟尖峰要么直接崩。
+
+### 账一：容量越大，单步延迟越高（吞吐与延迟对立）
+
+吞吐诱惑你把容量（batch 上限）开大——容量越大，一次权重搬运摊薄的 token 越多。但代价是：一个 decode step 现在要把 `capacity` 个 forwardStep 背靠背跑完，**才返回任何一个 token**。所以单步延迟（每个并发用户体感的卡顿）随容量近似线性上升：
+
+```
+cap= 1: 单步全 batch = 0.379 ms  => 每 token 平均 0.379 ms
+cap= 4: 单步全 batch = 1.482 ms  => 每 token 平均 0.370 ms
+cap=16: 单步全 batch = 5.829 ms  => 每 token 平均 0.364 ms
+```
+
+看右列"每 token 平均"——从 0.379 降到 0.364，吞吐效率确实随容量微升。但看左列"单步全 batch"——从 0.379 飙到 5.829，涨了 15 倍。这就是吞吐和尾延迟的对立：你为总吞吐开大容量，每个用户的等待时间（尤其是首字延迟 TTFT）就被拉长。真实引擎必须给容量设上限，精确地封住这条尾延迟。这也是为什么生产系统的 `max_num_seqs` / `max_num_batched_tokens` 是要调参的硬约束，不是越大越好。
+
+### 账二：KV 显存被并发请求撑爆，必须拒绝不能 OOM
+
+每接纳一个请求，就要为它预留 KV cache 显存。盲目接纳，迟早在 decode 跑到一半时 OOM（内存溢出）——这是最坏的失败时机：算力已经投进去了，请求半途崩掉，全白费。正确的调度器在**接纳时**就算显存账，装不下就拒绝或排队（backpressure，反压），而不是跑崩：
+
+```
+KV 池预算 = 6.00 MiB (est.), 每序列保留 seq=256 => 512.00 KiB (est.)
+在第 13 个请求处拒绝: 6.00 MiB + 512.00 KiB > 6.00 MiB (est.)
+=> 接纳 12 个请求 (占 6.00 MiB est.), 拒绝 52 个
+理论上限 = floor(6.00 MiB / 512.00 KiB) = 12 序列
+```
+
+代码里这是一段接纳控制的加法，关键在"先算后纳"：
+
+```ts
+// admission control: only admit if the running KV total still fits the budget.
+if (admittedBytes + perSeqBytes <= KV_BUDGET_BYTES) {
+  admittedBytes += perSeqBytes;
+  admittedCount++;
+} else {
+  rejected++;
+  // ... reject, don't OOM
+}
+```
+
+注意这里假设每序列**保守预留** `seq=256`（maxSeq）的 KV。问题来了：绝大多数请求根本生成不到 256 个 token，这部分预留是纯浪费——理论上限被这个保守假设压到了 12 个。这正是第 05 章 paged KV 要解决的：把 KV 切成固定大小的 page 按需分配，让预留接近实际用量，把并发数从"按最坏情况预留"解放出来。本章先把账算明白：调度器必须主动 backpressure，OOM 不是选项。
+
+## ⚡ 前沿：chunked prefill —— 连续批的下一层
+
+连续批解决了 decode 阶段的队头阻塞，但还留了个尖刺没拔：**prefill 和 decode 抢同一个调度步**。一个新请求带着长 prompt 进来，它的 prefill 是一次大矩阵乘，会把这一步撑得很长——而同 batch 里那些正在 decode 的请求，本来每步很快出字，现在被这个长 prefill 拖住，吐字突然卡一下。用户体感就是流式输出"一顿一顿"。
+
+2024 年的 **chunked prefill**（分块预填充，Sarathi-Serve 提出，现为 vLLM 默认）给出了下一层解法：把长 prefill 切成小片，和 decode 步**交错调度**——这一步处理一个 prefill 分片 + 一批 decode token，下一步再来一个 prefill 分片，让每一步的计算量大致均匀，从而消除 prefill 长请求对 decode 延迟的尖峰干扰。它把"prefill vs decode 谁先谁后"从二选一变成了细粒度混合。
+
+但这事**目前没有通用最优解，仍在活跃研究**：分片切多大（chunk size）是个调参难题——切太小，prefill 的大矩阵乘失去算力密集的优势，吞吐掉；切太大，又压不住 decode 的延迟尖峰。最优 chunk size 依赖模型、硬件、流量的 prefill/decode 比例三者耦合，没有放之四海的公式，目前靠 per-deployment 调参和启发式自适应。更前沿的方向是 prefill/decode 分离（disaggregated serving，把两阶段拆到不同 GPU 池各自优化，如 DistServe/Mooncake），但那又引入跨节点 KV 传输的新成本——属于另一个开放战场。
+
+把这章收个口：连续批用利用率换吞吐（实测 53% → 89%、1.57x），代价是接管了容量与显存两笔硬账，而且 maxDrift 必须恒为 0——调度只改编排，绝不改单序列数学。下一章 05 接手本章遗留的显存浪费问题：当并发请求的 KV 长度参差不齐时，怎么用 paged KV 把"按最坏情况预留"变成"按需分页"。

--- a/src/content/library/llm-inference/05-PagedAttention.md
+++ b/src/content/library/llm-inference/05-PagedAttention.md
@@ -1,0 +1,225 @@
+---
+title: "PagedAttention：像操作系统管内存一样管 KV 缓存"
+slug: "05"
+collection: "llm-inference"
+order: 5
+summary: "第 04 章的连续批让 GPU 不再空转，但它把每个请求都按 maxSeq 预留连续 KV 空间，实测内部碎片高达 62.8%。这章借操作系统的虚拟内存思路把 KV cache 切成定长 block、用 block table 做逻辑到物理的映射，消除碎片、把固定显存下的并发数翻 4 倍，并证明分页 bit-for-bit 不改变输出（drift=0）。最后把 block 共享推到 prefix caching 雏形，接上第 06 章投机解码对吞吐的下一刀。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+第 04 章的连续批（continuous batching，一有请求结束就立刻补新请求进 batch）把 GPU 的空转填满了，但它有一个被我们刻意放过去的账没算：每个请求的 KV cache（注意力的键值缓存，自回归解码时缓存历史 token 的 K/V 避免重算）到底占多少显存。答案很难看。跑一下本章的配套程序你会看到这一行：
+
+```
+连续预留 (每请求占 maxSeq=256) = 1.50 MiB (est.), 内部碎片 = 62.8%
+```
+
+三个请求，实际只用了 572 KiB 的 KV，却预留了 1.50 MiB，**62.8% 的显存是预留了从没碰过的**。在生产里 KV cache 是显存的头号消费者，连续批能塞多少请求几乎完全由 KV 显存决定——不是由算力决定。所以这一章不解决"算得快不快"，解决"**同样的卡能不能多塞几倍请求**"。这是把第 04 章调度器的内存利用率从"够用"推到"榨干"的关键一跳。
+
+本章配套代码：`examples/llm-inference-from-scratch/src/stage05-paged-kv.ts`。下文所有数字都来自它的真实运行输出，估算值标 `(est.)`。
+
+## 一、连续 KV 缓存怎么坏的：内部碎片
+
+### 为什么连续缓存必须预留 maxSeq
+
+先回到第 02 章建立的连续 KV cache。它的物理形态是一段连续数组，按 `[maxSeq, kvDim]` 布局，解码时一个位置一个位置往里写。问题出在"它得提前知道要多长"。
+
+自回归解码是一边生成一边追加的：你发起请求时根本不知道模型会吐 3 个 token 还是 235 个 token。连续数组要支持"再追加一个位置"有两条路：要么每加一个 token 就 realloc + 拷贝整段历史（O(n²) 的拷贝量，生产里不可接受），要么一次性按最坏情况 `maxSeq` 预留到顶、之后只往里填。生产引擎选后者——**为每个请求预留 maxSeq 个连续槽位**。
+
+代价就是上面那 62.8%。配套程序 (a) 段模拟了一个真实并发批：三个请求的实际长度分别是 3、48、235 token（来自 `core/tokenizer.PROMPTS`），但连续缓存对每个都按 `maxSeq=256` 预留：
+
+```
+[a] 内存占用: 连续预留 vs 分页 (同一批并发请求)
+    并发请求实际长度 = [3, 48, 235] tokens
+    实际用到的 KV (3 请求合计) = 572.00 KiB (est.)
+    连续预留 (每请求占 maxSeq=256) = 1.50 MiB (est.), 内部碎片 = 62.8%
+```
+
+那个 3-token 的请求最惨：用了 3 个槽，占着 256 个。这种"预留了但没用到的尾巴"在操作系统里有个名字——**内部碎片（internal fragmentation，已分配但用不上的空间）**。
+
+### 这是设计缺陷不是参数没调好
+
+有人第一反应是"把 maxSeq 调小点不就行了"。不行。`maxSeq` 是你愿意支持的最长对话上限，调小等于砍功能；而且只要 `maxSeq` 远大于"典型请求实际长度"——这在真实流量里永远成立，长尾请求少、短请求多——碎片就消不掉。**碎片的根因是"用连续数组表示一个长度未知的序列"这个数据结构选择本身**，不是某个旋钮。
+
+这正是 2023 年 vLLM 那篇 PagedAttention 论文的出发点：他们测真实工作负载，发现连续 KV cache 的有效利用率常常只有 20%-40%，剩下全是这种碎片加上"为了对齐预留的整块"。要根治，得换数据结构。
+
+## 二、把 OS 虚拟内存搬过来
+
+### ✦ 真正的洞见：打破"KV 是连续数组"这个假设
+
+操作系统几十年前就解决过一模一样的问题。进程要一段"看起来连续"的内存，但物理内存被切成定长的页（page），进程拿到的是逻辑地址，靠一张**页表（page table）**把逻辑页映射到任意物理页帧——物理上根本不连续。这样物理内存按页粒度按需分配，碎片被限制在"最后半页"。
+
+PagedAttention 就是把这套搬到 KV cache 上。这里要点破一件事：**PagedAttention 真正的洞见不是"分页"这个机械动作，而是它敢于打破"KV cache 必须是一段连续数组"这个被所有人默认接受的前提**。一旦你接受"KV 可以非连续寻址、靠一张表去查",batch 能塞的请求数就能翻数倍——后面 (b) 段会给出 4 倍的实测。分页只是兑现这个洞见的手段;洞见本身是"质疑那个没人质疑的假设"。
+
+映射关系是这样的（注意力机制术语对操作系统术语）：
+
+| 操作系统 | PagedAttention | 在本章代码里 |
+|---|---|---|
+| 物理页帧 | KV block（定长，存 `blockSize` 个位置的 K/V） | `PagedKVPool.blocksK/blocksV` |
+| 页表 | block table（逻辑块号 → 物理块号） | `PagedSeq.blockTable` |
+| 缺页 → 分配页帧 | 写到新逻辑块 → 分配物理 block | `pagedStep` 里的 `allocBlock` |
+| 空闲页链表 | free list（回收的 block 等待复用） | `PagedKVPool.freeList` |
+
+### block size：唯一的调优旋钮
+
+block 多大是核心权衡，所以代码里它是个命名常量不是字面量：
+
+```ts
+// examples/llm-inference-from-scratch/src/stage05-paged-kv.ts
+const BLOCK_SIZE = 8;
+```
+
+block 越小，最后半块的浪费越少（内部碎片上限就是 `blockSize`，与 `maxSeq` 无关了），但 block table 条目越多、间接寻址开销越大;block 越大反过来。真实引擎一般用 16。这里用 8，是为了让长度 3/48/235 的 toy 请求横跨好几个 block,让"最后那个没填满的块"在数字上看得见,而不是被取整抹平。
+
+`PagedKVPool` 是一个所有序列共享的物理 block 池。每个 block 对**一层**存 `blockSize` 个位置的 K 和 V,行主序平铺成 `[blockSize, kvDim]`——这个布局是刻意选的,它和第 02 章连续 cache 打包 K/V 的布局**字节兼容**,所以把一串 block 收集起来,就能直接喂给原来的注意力 kernel。这个细节是第三节"输出不变"能成立的全部秘密。
+
+`allocBlock` 是分配器,优先从 free list 拿回收块,拿不到才向池子申请新块——和 OS 优先复用空闲页帧一个套路:
+
+```ts
+// examples/llm-inference-from-scratch/src/stage05-paged-kv.ts — allocBlock
+function allocBlock(pool: PagedKVPool): number {
+  const idx = pool.freeList.length > 0 ? pool.freeList.pop()! : pool.nextFresh++;
+  // ...为每一层把该物理块的 K/V 数组按需分配并清零...
+  return idx;
+}
+```
+
+每个序列自己持有一张 block table 加一个已填位置数 `len`:
+
+```ts
+type PagedSeq = {
+  blockTable: number[]; // 逻辑块 i 存在物理块 blockTable[i]
+  len: number;          // 当前已缓存的位置数
+};
+```
+
+### 一步解码:gather → 算 → scatter
+
+`pagedStep` 是分页版的单步解码,对照第 02 章的 `forwardStep` 看,它和连续路径**唯一的区别就在 K/V 历史怎么取、怎么存**:
+
+```ts
+// examples/llm-inference-from-scratch/src/stage05-paged-kv.ts — pagedStep 核心
+// 缺页式分配:这个 token 要落的逻辑块还没有物理块,就分一个
+const logicalBlock = Math.floor(pos / BLOCK_SIZE);
+if (seq.blockTable[logicalBlock] === undefined) {
+  seq.blockTable[logicalBlock] = allocBlock(pool);
+}
+// ...每层:
+//  GATHER —— 把分散在各 block 里的 pos 行历史,收集进一段连续 scratch,
+//            正好是 blockStep 期望的 [pos, kvDim] 布局
+const kHist = new Float64Array(pos * kvDim);
+for (let p = 0; p < pos; p++) {
+  const phys = seq.blockTable[Math.floor(p / BLOCK_SIZE)];
+  kHist.set(pool.blocksK[l][phys].subarray(/* 该位置在块内的偏移 */), p * kvDim);
+}
+const r = blockStep(h, w, pos, kHist, vHist, pos, cfg); // 完全相同的注意力运算
+//  SCATTER —— 把刚算出的这一行 K/V 写回它对应的物理块槽位
+pool.blocksK[l][phys].set(r.k, slotInBlock * kvDim);
+```
+
+三步:**gather**(把非连续的历史块收拢成连续 scratch)→ 跑**和连续路径逐字节相同的** `blockStep` → **scatter**(把新 K/V 散写回物理块)。这个 gather 是分页用运行时换显存付的成本。在 toy 里我们把它显式写出来让机制可见;真实引擎会把 gather 融进注意力 kernel(所谓"paged attention kernel"),让它近乎免费——这是工业实现和教学实现的关键差距,值得记一笔。
+
+## 三、最该守的不变量:分页不准改变输出
+
+分页只是搬字节,**数学一个比特都不能动**。这是整章承重的不变量:如果分页悄悄改了 logits,那它就不是"优化"而是"引入了静默的精度 bug",再省显存也得回滚。
+
+配套 (c) 段把分页路径的最后一个 token 的 logits 和两个参照逐位对拍:一个是 O(seq²) 的无缓存参照 `forwardNoCache`,一个是第 02 章的连续缓存 `forwardStep`。三个长度都测——这是刻意避开 N=1:分页 bug 常常藏到"序列跨过 block 边界"才暴露,48 和 235 都跨了多块,3 也跨了不止一块(blockSize=8 下 3 token 占 1 块,48 占 6 块,235 占 30 块):
+
+```
+[c] 正确性: 分页注意力 logits 逐位对拍 (drift 必须 ≈0)
+    len=  3 (跨1块): drift vs reference=0.00e+0, vs contiguous=0.00e+0, argmax match=true
+    len= 48 (跨6块): drift vs reference=0.00e+0, vs contiguous=0.00e+0, argmax match=true
+    len=235 (跨30块): drift vs reference=0.00e+0, vs contiguous=0.00e+0, argmax match=true
+    最坏 drift = 0.00e+0 -> 分页不改变任何输出 (bit-for-bit)
+```
+
+最坏 drift = `0.00e+0`,bit-for-bit 一致。为什么能做到零漂移、连浮点最后一位都不差?因为 gather 把分散的块收拢成的那段 scratch,布局和连续 cache 完全一样,送进的是**同一个** `blockStep` 函数。运算顺序不变、加法结合性不变,浮点结果就一位不差。**正确性不是靠运气,是靠"复用同一个运算核"这个设计决策买来的**——这也是为什么 `pagedStep` 宁可显式 gather 也不另写一套注意力:另写一套,迟早因为求和顺序不同引入 1e-7 级别的漂移,然后你要花一周去查"为什么分页后第 200 个 token 偶尔不一样"。
+
+## 四、固定显存预算下,并发数翻 4 倍
+
+碎片消掉了,直接收益是同样的显存能塞更多请求。(b) 段在一个固定预算下对比两种分配器:
+
+```
+[b] 固定显存预算下的最大并发请求数
+    预算 = 64.00 MiB (est.), 代表性工作长度 = 64 tokens
+    连续: 每请求预留 maxSeq=256 -> 512.00 KiB/请求 -> 最多 128 并发
+    分页: 每请求只占 8 块 -> 128.00 KiB/请求 -> 最多 512 并发
+    分页并发能力 = 连续的 4.0x
+```
+
+连续路径不管请求实际多长,都按 `maxSeq=256` 预留 512 KiB,64 MiB 只够 128 个;分页只按工作长度 64 token 占的 8 个 block(128 KiB)算,塞得下 512 个。**4 倍**。
+
+把它接回第 04 章:连续批的吞吐上限本质是"batch 里能同时 in-flight 多少请求",而这个数被 KV 显存卡死。分页把每请求的显存占用从"按最坏预留"降到"按实际占用",直接把这个上限抬高数倍。所以 PagedAttention 不是和连续批二选一,它是连续批的**地基**——vLLM 把两者一起上,才有了那条出名的吞吐曲线。
+
+> 诚实标注:64 MiB 预算和这些绝对 KiB 数是 toy 配置(blockSize=8,kvDim=32,nLayers=4)下的精确浮点估算,标 `(est.)`,不是真实显卡的 RSS 读数。会迁移到生产的不是这些绝对数,是那个 **4.0x 的比值**——它只取决于 `maxSeq / 工作长度` 的比例,真实场景里(maxSeq 几千、典型对话几百)这个比值往往更夸张。
+
+## 五、block 共享:prefix caching 的雏形
+
+分页还顺手解锁了一个连续 cache 根本做不到的能力。block table 是一层间接——既然逻辑块映射到物理块,那**两个序列的 block table 完全可以指向同一个物理块**。当多个请求共享同一段前缀(最典型:同一个 system prompt、多轮对话的历史),这段前缀的 KV block 在物理上只存一份,所有请求的 block table 都指过去。
+
+(d) 段模拟了 4 个请求共用一个 system prompt:
+
+```
+[d] prefix 共享: 多个请求共享同一 system prompt 前缀
+    system prompt = 63 tokens -> 可共享 7 个整块 (56 tokens), 余 7 tokens 不满整块
+    4 个请求, 每个别名同 7 个物理块 (共 28 次别名, 0 拷贝)
+    内存: 共享 21 块 vs 朴素各存一份 42 块 -> 省 336.00 KiB (est.)
+    prefill 时间: 共享 = 63.33ms (前缀1次 25.03ms + 4尾巴 38.30ms)
+                  朴素 ≈ 138.42ms (est.: 前缀重算4次), 加速 = 2.19x
+```
+
+两笔账都省了。**显存**:21 块 vs 朴素的 42 块,省 336 KiB。**prefill 计算**(把整段 prompt 喂进去填满 KV 的过程):前缀只算一次,加速 `2.19x`——别小看这个,prefill 是计算密集的,把 N 份重复 prefill 砍成 1 份,直接降低首 token 延迟(TTFT)和总算力。
+
+这里有个真实约束要点破:**只能共享整块**。代码里 63 token 的 prompt 只能共享前 `floor(63/8)=7` 个整块(56 token),余下 7 个 token 不满一块,各请求自己存:
+
+```ts
+// examples/llm-inference-from-scratch/src/stage05-paged-kv.ts
+// 共享前缀必须落在 block 边界上才能整块共享 —— vLLM 也只共享满块
+const sharedBlocks = Math.floor(sysIds.length / BLOCK_SIZE);
+```
+
+共享是只读别名(本例 0 拷贝)。但一旦某个请求要在共享区上写——比如各自的对话分叉了——就必须先复制出自己的私有块再写,这就是 **copy-on-write(写时复制,共享只读、写时才分裂)**,和 OS 进程 fork 共享内存页是同一个机制。本章 demo 是纯只读共享,把 CoW 的触发点点到为止。
+
+### ⚡ 前沿:从 block 共享到工业级 prefix caching
+
+block 共享在 2024-2025 长成了一个吞吐利器,但**它仍是活跃研究区,没有放之四海的通用解**:
+
+- **vLLM automatic prefix caching**:自动检测请求间的公共前缀并复用其 KV block,对"固定 system prompt + 变化 user 输入"的场景近乎白嫖。
+- **SGLang RadixAttention**:用基数树(radix tree,按公共前缀压缩的字典树)组织所有请求的 KV,前缀共享从"线性扫描找公共块"升级成树上的前缀匹配,多轮对话和共享 prompt 场景吞吐能翻倍。
+
+为什么说没通用解?难点全在**缓存策略**而非机制本身:缓存的 prefix block 什么时候淘汰(LRU?按命中率?)、显存吃紧时优先保谁、被复用的块被原请求改写时的 CoW 时机、跨请求的引用计数怎么在高并发下不出竞态——这些是典型的缓存管理难题,工作负载一变最优策略就变。机制(block 可共享)是确定的,**策略仍在研究**。把这一节和第 04 章连起来看:连续批解决"GPU 别空转",分页解决"显存别浪费",prefix caching 解决"重复计算别重复算"——一层一层往上榨。
+
+## 六、失败模式:一个错条目 = 静默串话
+
+分页用"一层间接"换了效率,代价是引入了一个连续 cache 根本不存在的新危险:**block table 必须永远正确,一个条目错了不会崩,只会静默地让你读到别人的 KV**。
+
+(e) 段故意制造这个 bug:两个独立请求 A、B 在同一个池里 prefill 完,然后把 B 的逻辑块 0 改指向 A 的物理块 0——这正是 block 分配器 off-by-one,或者引用计数竞态会产生的错误:
+
+```ts
+// examples/llm-inference-from-scratch/src/stage05-paged-kv.ts
+const goodPhys = seqB.blockTable[0];
+seqB.blockTable[0] = seqA.blockTable[0]; // <-- 制造错位:B 的第 0 块指向了 A 的
+```
+
+结果:
+
+```
+[e] 失败模式: block table 映射错位 -> 读到别的请求的 KV (logits 污染)
+    请求 B 正确 argmax = 255
+    block table 错位后 B 的 argmax = 255 (本例恰好未翻转, 但 logits 已偏移)
+    logits 漂移 = 8.04e-1 (≫0: 读到了 A 的 KV, 输出被污染)
+    教训: 分页用一层间接换效率, 代价是 block table 必须永远正确 — 一个错条目=静默串话, 不崩溃, 最难查
+```
+
+注意这个失败有多阴险:argmax 这次**恰好没翻**(还是 255),但 logits 已经漂了 `8.04e-1`——比第三节那个 `0.00e+0` 的不变量差了十几个数量级。它不抛异常、不崩溃、有时连最终 token 都看着正常,但 B 的注意力实实在在读到了 A 的历史。在生产里这就是**跨请求串话**:用户 B 的回答里混进了用户 A 的上下文。这类 bug 没有栈回溯、复现还看运气(取决于 argmax 翻没翻),是分页引擎里最难查的一类。
+
+这也解释了为什么真实引擎在 block 分配/释放/引用计数这套上极度谨慎、测试覆盖拉满:第三节的 `drift=0` 是分页的承诺,而这个承诺**完全建立在 block table 永不出错之上**。间接寻址是把双刃剑——它给了你共享和按需分配,也给了你一个"错了不报警"的攻击面。
+
+## 小结与承接
+
+这一章做的事:把 KV cache 从"每请求一段按 maxSeq 预留的连续数组"换成"定长 block + block table 映射",拿操作系统虚拟内存的成熟思路,消掉了 62.8% 的内部碎片,在固定显存下把并发从 128 推到 512(4.0x),还证明了这一切 bit-for-bit 不改变输出(drift=0)。顺带靠 block table 的间接性解锁了 prefix 共享,省显存又省重复 prefill(2.19x),这就是工业级 prefix caching 的雏形。代价是认清了一个新危险:间接寻址下,一个错的 block table 条目会静默串话。
+
+到这里,第 04 章(GPU 别空转)+ 第 05 章(显存别浪费)已经把"把现有算力和显存榨干"这条线走完。第 06 章换思路——不再榨现有资源,而是**用小模型猜、大模型验**的投机解码(speculative decoding)去攻"自回归一次只能出一个 token"这个延迟根因,从另一个维度再要一刀吞吐。

--- a/src/content/library/llm-inference/06-投机解码.md
+++ b/src/content/library/llm-inference/06-投机解码.md
@@ -1,0 +1,199 @@
+---
+title: "投机解码：用小模型抢跑，大模型一次验一串"
+slug: "06"
+collection: "llm-inference"
+order: 6
+summary: "前几章把 decode 一步一 token 的代价摊开了：它访存密集、算力闲置（第 2 章 KV cache、第 5 章分页 KV）。这章用一个反直觉的招数把那段闲置算力换成 token——让便宜的 draft 一口气猜 K 个，大模型一次前向并行验完，按拒绝采样接受最长正确前缀。核心不变量是输出分布与直接采样严格一致（用 KL 对拍证明「快了没变质」），加速天花板由接受率决定，而接受率由 draft 和 target 的对齐度决定。下一章（第 7 章量化）走另一条省钱路线：压权重而非省前向。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+decode 阶段每一步只产 1 个 token，但要把整个模型的权重从显存搬一遍。第 2 章我们量过这个账：自回归生成是访存密集（memory-bound，瓶颈在搬数据不在算）的，每步的矩阵乘都是「拿一个长度 1 的向量去乘几百 MB 的权重」，GPU 的算力（FLOPs）几乎全闲着。这是个刺眼的浪费——你为搬一次权重付了钱，却只换回一个 token。
+
+投机解码（speculative decoding）就是冲着这块闲置算力来的。它的赌注是：既然 target 大模型做一次前向，顺带验证 1 个位置和验证 8 个位置的访存代价几乎一样（权重只搬一遍），那就让一个便宜的 draft（草稿模型）先猜出 K 个 token，再让 target 用**一次前向**把这 K 个位置的 logits 全算出来，逐个验证。猜对的白赚，猜错的从那一刻截断、用 target 自己的分布补一个。运气好时一次 target 前向吐出 K+1 个被接受的 token，运气差时退化回每次 1 个。
+
+这一章我先把「为什么它不改变输出」证明给你看（这是能上线的全部理由），再拆实现里最容易写错的一处——KV cache 回滚，最后用实测数字把「加速比 = f(接受率) = f(对齐度)」这条因果链钉死，包括它什么时候变成**负优化**（越投机越慢）。配套代码全在 `examples/llm-inference-from-scratch/src/stage06-speculative.ts`，下面引用的数字都来自它的真实运行。
+
+## 一个 round 在做什么
+
+先把机制讲清楚，否则后面所有数字都悬空。设 `C` 是当前已提交（committed）的序列长度，一个 round 分五步：
+
+1. **draft 提议**：从 draft 当前的 next-token 分布出发，自回归吐 K 个 token。draft 便宜，这 K 步几乎不要钱。
+2. **target 验证**：把这 K 个提议喂进 target，**一次前向**算出 K+1 个位置的 logits（K 个提议位 + 1 个 bonus 位）。这是 teacher-forcing（拿已知序列并行算每个位置的预测），所以可以一次算完——这正是省钱的来源。
+3. **逐个接受/拒绝**：从左到右走。贪心模式下，提议 token 等于 target 在该位的 argmax 才接受，第一个不等就停、改用 target 自己的 argmax。采样模式下用拒绝采样（rejection sampling），按概率 `min(1, p_target/p_draft)` 接受，第一次拒绝就从残差分布重采一个、停。
+4. **bonus token**：若 K 个全接受，验证时算出的最后一个分布免费再产一个 token——最好情况一次 target 前向提交 K+1 个 token。
+5. **回滚修复**：被拒提议对应的 KV cache 行是「基于猜错的历史算出来的」，是毒，必须切掉。
+
+代码里这个 round 是 `generateSpeculative()` 的主循环（`stage06-speculative.ts` 第 257–364 行）。我把接受/拒绝那段贴出来，因为它是正确性的核心：
+
+```ts
+// sampling speculative: rejection sampling against the target distribution.
+const pT_all = softmaxProbs(targetLogitAt[j], mode.temperature);
+const pD_all = softmaxProbs(draftLogitAt[j], mode.temperature);
+// accept with prob min(1, pT/pD). pD>0 always (proposed[j] was sampled from pd).
+const acceptProb = pD_all[tok] > 0 ? Math.min(1, pT_all[tok] / pD_all[tok]) : 1;
+if (rng() < acceptProb) {
+  out.push(tok); accepted++;
+} else {
+  // first rejection: resample from residual norm((p_t - p_d)_+).
+  // ... 见下文
+  break;
+}
+```
+
+`min(1, p_target/p_draft)` 不是随手拍的阈值。它和那个残差重采（residual resample）一起，是 Leviathan 等人（2023）和 Chen 等人（2023）那篇证明的精确构造——目的就是让最终提交 token 的边际分布（marginal distribution，边缘化掉所有中间随机性后看到的那个分布）**恰好等于** target 直接采样的分布。下一节我把这件事测出来。
+
+## 这章最该内化的一句话：它只换延迟，不换质量
+
+投机解码是个延迟（latency）trick，不是质量 trick。它不会让输出「更好」也不会「更差」——它产出的就是 target 本来会产出的那个分布，只是产得更快。这句话听起来像营销话术，但它有严格证明，而且能测。`stage06` 的 (a) 段就专门干这件事。
+
+这里有个**极易踩的坑**：等价是分布等价（distributional），不是逐 seed 等价。投机解码比普通采样多抽随机数（接受的硬币、残差重采），所以同一个随机种子下两者**不会**产出相同的 token 序列。如果你写个「同 seed → 同序列」的测试去验正确性，它会**误报失败**——而代码其实是对的。正确的验法分两个 regime：
+
+**a1 贪心（argmax）**：贪心是确定的，所以序列必须逐 token 完全相等。而且对**任意** draft 都成立——因为接受规则在每个位置要么接受恰好等于 target argmax 的 token，要么直接提交 target 的 argmax。实测：
+
+```
+[a1] greedy (argmax): speculative sequence must equal target-only
+     K=2: identical=true
+     K=4: identical=true
+     K=6: identical=true
+```
+
+**a2 采样（temp=1）**：随机的，所以验的是分布。跑 4000 次独立采样，对比投机和 target-only 的首 token 经验分布，算 KL 散度（KL divergence，衡量两个分布差多远）：
+
+```
+[a2] sampling (temp=1, 4000 runs): empirical first-token KL
+     KL(speculative || target-only) = 6.69e-2 nats
+     KL(target-only' || target-only)  = 6.77e-2 nats  (sampling noise floor)
+     speculative KL within ~noise floor: true
+```
+
+关键在那个**噪声地板（noise floor）**：两个独立的 target-only 直方图之间的 KL 是 `6.77e-2 nats`，纯粹是 4000 个样本的采样噪声。投机 vs target 的 KL 是 `6.69e-2`，**比噪声地板还小一点点**。也就是说，两个分布的差异已经淹没在采样噪声里，无法区分——这不是「argmax 碰巧一样」，是**分布相等**。a2 这里故意用了一个弱（depth-2）draft，让接受率明显低于 100%、残差重采路径被真正走到；如果连这种条件下等价都成立，说明那套接受/重采的数学是对的，不是被绕过去了。
+
+这就是为什么投机解码敢上线：你不需要重新评测质量。它和原模型在统计上不可区分。
+
+> **⚠ 为什么不能用「极小 temperature」假装贪心**：这个 toy 模型未经训练，top-2 的 logit 差距很小，temp=0.02 时第二名还握着约 10% 的概率质量。低温采样**不是**确定的，会让 a1 的逐 token 匹配测试假性失败。贪心必须是真正的 argmax 路径，不是温度极限。代码里 `DecodeMode` 把 `greedy` 和 `sample` 做成两条独立分支（第 135–142 行）正是为此。
+
+## 真正容易写崩的地方：KV cache 回滚
+
+分布等价的证明很漂亮，但能不能落地，卡在一个脏活上——KV cache 回滚。这是每个从零实现第一次都写错的地方，写错了上面那个等价保证会**静默失效**（输出还在跑，分布已经歪了，而且没有任何报错）。
+
+问题出在：一个 round 里 draft 长了 K 个提议，target 长了 K 个验证。被拒绝的提议（以及它们之后的位置）对应的 cache 行，是「以猜错的 token 为历史」算出来的 key/value。下一步前向会去 attend 这些行——它在读垃圾。`stage06` 的 `rollbackCache()`（第 107–114 行）干的就是切掉这些毒行：
+
+```ts
+function rollbackCache(cache: KVCache, keep: number, cfg: ModelConfig): void {
+  const kvDim = cfg.nKVHeads * cfg.dHead;
+  for (let l = 0; l < cfg.nLayers; l++) {
+    cache.k[l] = cache.k[l].slice(0, keep * kvDim);
+    cache.v[l] = cache.v[l].slice(0, keep * kvDim);
+  }
+  cache.len = keep;
+}
+```
+
+注意它用了 `cfg.nKVHeads`（不是 `nHeads`）算 `kvDim`——这是第 2 章 GQA（分组查询注意力，多个 query head 共享一组 KV head）省下来的那个维度。切片必须按 KV 维度切，且每层都切，`cache.len` 是位置的唯一真源，回滚后必须同步重置。round 结束时的不变量是：tCache 和 dCache 都必须**恰好**代表 `prompt + 已提交输出`——不多一行。多一行就是毒。
+
+代码里还有个更妙的优化叫**延迟边界 token（deferred boundary）**：每个 round 拒绝点（或全接受时的 bonus）产生的那个 token，它的 target cache 行**不在本 round 写**，而是推迟成下一个 round 验证步的第一个输入。为什么？因为喂这个 pending token 进 target 时，顺带就算出了下一个提议位的 logits——于是边界 token 的 cache 行「免费」创建，target 不为它多花一次前向（第 279–293 行）。
+
+这件事是有代价的，得说清楚（这就是失败模式那一节要量化的根）：**如果没有这个延迟边界融合，投机在这个串行 toy 里会比普通 decode 做更多 target 前向**——因为每个 round 的边界 token 都得额外喂一次。延迟边界把「每 round 额外一次 target 前向」消掉，让真实引擎做到大约「每个被提交 token 一次 target 前向」（接受越多，越少于一次）。少了这步，投机连打平都难。
+
+## 接受率随对齐度变化：✦ 加速天花板的真正旋钮
+
+现在到本章最重要的因果链。投机的加速天花板由**接受率**决定，而接受率由 draft 和 target 的**分布对齐度**决定。这不是定性的「draft 越好越快」，是可以画出曲线的。
+
+`stage06` 的 (b) 段直接拿对齐度 α 当旋钮，构造 draft 分布 `p_draft = normalize(α·p_target + (1-α)·uniform)`：α=1 时 draft 就是 target，α=0 时 draft 是均匀噪声。为什么不用「层数截断的 draft」当旋钮？因为这个未训练 toy 模型的每个 next-token 分布都接近平坦，接受规则 `min(1, p_t/p_d)` 对几乎任何 draft（哪怕随机权重）都返回很高的接受概率——层数旋钮太弱，推不动接受率，会让失败模式的演示**不诚实**（随机 draft 看起来也「能用」）。直接拨 α 是忠于机制的：一个对齐更好的 draft，按定义就是分布更接近 target 的 draft。
+
+还有一处必须强调的实验设计：温度。在 temp=1 下，这个 toy 的 target 本身就接近均匀，连均匀 draft（α=0）都能「碰对」约 78%，对齐依赖完全看不见。所以探针跑在 **temp=0.15**（target 被压尖，这才是真实 serving 的工作区）。结果：
+
+```
+[b] 接受率随 draft 质量(对齐度 α)变化 (peaked temp=0.15, K=4):
+    alpha   meaning                acceptRate   meanAccepted/round (of K=4)
+    0.00    draft = uniform noise     8.4%        0.09
+    0.50    partial alignment       53.9%        1.07
+    0.90    partial alignment       90.5%        3.15
+    0.99    partial alignment       99.1%        3.92
+    1.00    draft = target         100.0%        4.00
+```
+
+读这张表：接受率随对齐度**单调上升**。α=1 时每个 draft token 都被接受，一 round 提交 K+1=5 个 token；α=0 时塌到约 1 token/round——退化回普通 decode，但你还白付了 draft 的钱。中间那段（α=0.9 → 90.5% 接受 → 平均 3.15 个/round）才是真实系统的工作点。
+
+这条曲线解释了一个常被误解的设计选择：**为什么自投机（self-speculation）比外挂小模型更稳**。
+
+外挂一个独立训练的小模型当 draft，它的分布和 target 是两个模型，对齐度全凭运气和训练，分布漂移时接受率会掉。而自投机——同模型早退（early-exit，跑到浅层就出预测）、或 Medusa 那样在主干上挂多个预测头——draft 和 target **共享底层表示**，分布天然对齐。映射到上表，自投机相当于把 α 钉在高位，于是接受率稳定地落在曲线右段，而不是随两个独立模型的漂移在曲线上来回滑。这就是 ✦ 的全部内容：天花板由接受率定，接受率由对齐定，所以「让 draft 和 target 同源」是把对齐度从「碰运气」变成「结构保证」。
+
+## 加速比随 K 变化，以及诚实的甜点
+
+接受率高不等于一定快——还得看你猜多长（K）划不划算。`stage06` 的 (c) 段量这个，但它有一个**必须先说清的诚实声明**，否则你会被 wall-clock 数字骗。
+
+加速分两个口径：
+
+- **ALGO speedup** = N / target 验证 pass 数。这是纯算法口径，假设一次验证 pass（覆盖 K+1 个位置）就是**一次批处理前向**——这是真实硬件上的情况（访存密集，K+1 个位置一次算完，代价约等于一步 decode）。
+- **EFF speedup** = 诚实口径。把 draft 的开销也算进去：`effCost/token = (passes + draftRatio·draftForwards) / N`，speedup = 1/它。draft 跑在同一个加速器上，必须收费。
+
+这个 toy **测不出 ALGO 的 wall-clock 优势**——因为 `core/forwardStep` 是串行验证（K+1 个位置一个接一个跑 cached step），没有批处理并行可测。让投机变快的那个机制，恰恰是这个非批处理参考实现里缺席的。所以 wall-clock（ms）会看起来更慢，**别把它当结论**。结论看 EFF 列。实测（cheap aligned draft，temp=0.15，draftCost=0.25x）：
+
+```
+target-only baseline: 48 target passes (one per token), 35.63 ms serial (1347 tok/s)
+K    acceptRate   targetPasses   ALGO speedup   EFF speedup   (serialMs)
+ 1    71.4%          28         1.71x        1.14x              (50ms)
+ 2    46.9%          25         1.92x        1.10x              (60ms)
+ 4    53.3%          16         3.00x        1.37x              (58ms)
+ 6    44.3%          14         3.43x        1.30x              (68ms)
+ 8    25.8%          17         2.82x        0.94x  <- net slower(89ms)
+12    28.5%          12         4.00x        1.02x              (93ms)
+```
+
+EFF speedup 在**中间的 K 取峰值**（这里 K=4，1.37x），两头都差：
+
+- **K 太小**：验证 pass 摊不开。一次 target 前向只换回一两个 token，省下的前向不够多。
+- **K 太大**：提议的尾部 token 大概率被拒（接受率从 K=4 的 53% 掉到 K=8 的 26%），而一个 round 里第一个被拒就**截断整个 round**——后面那些 token 白猜了，但 draft 的钱已经付了。K=8 这一行直接 EFF=0.94x，**净变慢**。
+
+注意 ALGO 列一直在涨（K=12 到 4.00x），但那是「假设 draft 免费」的幻象。EFF 才是真账，它告诉你存在一个甜点 K，不是越大越好。真实引擎里这个甜点通常落在 K=4~8，取决于 draft 成本比和接受率曲线。
+
+（serialMs 那列正如声明所说，反映串行验证、看起来更慢，只为完全披露才打出来，不读作结论。)
+
+## 失败模式：什么时候投机是负优化
+
+最后把刀架到脖子上：投机不是免费的安全选项。draft 和 target 对齐度一塌，它会**变慢**——而且 K 越大坑挖得越深。这是上线前必须知道的边界。`stage06` 的 (d) 段对比对齐 draft（α=0.95）和失配 draft（α=0.0）：
+
+```
+[d] 失败模式: draft 与 target 对齐度对比 (peaked temp=0.15, draftCost=0.25x):
+    align        K    acceptRate   effCost/token   effSpeedup   verdict
+    aligned α=.95    2     95.5%        0.52            1.94x        useful (1.94x)
+    aligned α=.95    4     95.2%        0.42            2.40x        useful (2.40x)
+    aligned α=.95    8     95.0%        0.35            2.87x        useful (2.87x)
+    MISALN α=.00    2      9.5%        1.26            0.79x        NEGATIVE optimization (slower)
+    MISALN α=.00    4      8.4%        1.50            0.67x        NEGATIVE optimization (slower)
+    MISALN α=.00    8      9.6%        1.70            0.59x        NEGATIVE optimization (slower)
+```
+
+读这张表读出一件事：**优化的正负号只取决于对齐度**。
+
+对齐 draft（α=0.95）：effective cost/token < 1，是真加速，而且随 K 增长（K=8 到 2.87x），因为高接受率下大 K 把验证 pass 摊得更开。
+
+失配 draft（α=0.0）：接受率塌到约 9%，每个 round 只能提交约 1 个 token（基本就是 boundary token），**却仍要付 K 次 draft 前向**。于是 effective cost/token > 1，而且**随 K 恶化**（K=2 的 1.26 → K=8 的 1.70）。这就是负优化：你以为在加速，其实在烧钱。
+
+这里有个反直觉但必须接受的结论：**即便 draft 烂到家，输出仍然完全正确**。(d') 段用一个真正没用的 draft（不同种子的独立模型）跑贪心，确认序列依然逐 token 等于 target-only：
+
+```
+[d'] even with a TERRIBLE draft, greedy output === target-only: true
+     (speculative decoding trades speed for speed, never speed for quality)
+```
+
+「trades speed for speed」——拿可能的加速去赌，赌输了赔的是延迟，**永远不赔质量**。这是投机解码工程上最安心的性质：你可以放心地试一个 draft，最坏情况是变慢一点，不会悄悄污染输出。但「不会变质」不等于「值得开」——上线前你必须用真实流量量接受率，确认它落在曲线右段而不是塌到 9%。
+
+## ⚡ 前沿：怎么把接受率推到稳定 2-3x
+
+把上面的因果链倒过来看：既然加速由接受率定、接受率由对齐定，那 2024-2025 的研究方向就一目了然——**想办法让 draft 和 target 对齐得更便宜、更稳**。这是个仍在快速演进、**没有公认通用解**的领域，目前几条主线：
+
+- **EAGLE / EAGLE-2 / Medusa**：核心转变是在 **feature 层而非 token 层做 draft**。Medusa 在主干顶上挂多个预测头一次猜多个位置；EAGLE 进一步在特征（隐藏状态）空间自回归地预测下一个特征，再解码成 token——比直接在离散 token 空间猜对齐度高得多。它们能把接受率推到让长文本生成稳定 2-3x 的水平，且因为 draft 寄生在 target 上，对齐是结构性的（映射回 (b) 表，α 被钉在高位）。
+
+- **无 draft 的投机**：Lookahead decoding、n-gram / prompt-lookup 投机干脆**不要独立 draft 模型**——直接从已生成文本或 prompt 里捞 n-gram 当提议。零额外模型、零训练，在重复性强的文本（代码、引用、结构化输出）上接受率很高，但在低重复内容上接受率掉得快。
+
+为什么说没有通用解：接受率高度依赖**任务分布**。同一套 draft 在代码生成上 3x、在开放创作上可能只有 1.3x；最优 K、draft 深度、是否树状投机（一次提议多条分支再批量验证）都随负载变。EAGLE 系把天花板抬高了，但「给定任意 target + 任意负载，自动选出最优投机配置」仍是开放问题——目前还是靠针对部署场景实测调参，没有一键最优。
+
+---
+
+把这章和前后串起来：第 2 章告诉你 decode 为什么访存密集、算力闲置；这章把那块闲置算力换成 token，且零质量代价。它和**压缩权重**那条路线（第 7 章量化，从根上减少每次前向要搬的字节）正交——两者可以叠加：量化让单次 target 前向更便宜，投机让被接受 token 摊到的前向更少。真实生产引擎（vLLM、TensorRT-LLM）通常两个都开。下一章我们去拆量化，看 INT8 / INT4 怎么在精度和带宽之间做取舍。

--- a/src/content/library/llm-inference/07-量化int8int4.md
+++ b/src/content/library/llm-inference/07-量化int8int4.md
@@ -1,0 +1,259 @@
+---
+title: "量化 int8/int4：用精度换显存和带宽"
+slug: "07"
+collection: "llm-inference"
+order: 7
+summary: "第 02 / 05 章把 KV cache 的显存账算到了 token 级，第 06 章的投机解码靠多搬一遍小模型换吞吐——这章直接砍掉搬运量本身：把权重和 KV 从 float 压到 int8/int4，8x~16x 省显存、省带宽。我们实现对称量化的 per-tensor 与 per-channel，用 maxLogitDrift / perplexity 把精度损失钉在数字上，并复现量化的头号失败模式——单个离群值通道毁掉整个 tensor 的 scale。这是吞吐与显存的收尾章，把'精度-显存-速度'三角落到可跑代码上。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+decode 阶段（一次生成一个 token 的阶段）是 memory-bound（瓶颈在访存，不在算力）——这件事我们在第 01 章就量过，第 06 章讲投机解码时又用过一次：GPU 的算力远远跑赢它的内存带宽，所以每生成一个 token，瓶颈不是乘法做得快不快，而是把几个 G 的权重从显存搬到计算单元要多久。这一章的全部杠杆就压在这句话上：**如果一个权重不需要 64 位来表示，那它从显存到计算单元的搬运量也能等比例砍掉。** 把权重从 float 压到 int8，搬运量降到 1/8;压到 int4，降到 1/16。在 decode 这个访存瓶颈上，搬运量降多少，速度就近似涨多少。这通常是整个推理引擎里单点收益最高的一个优化——比第 06 章的投机解码更直接，因为它砍的是瓶颈本身而不是绕过它。
+
+代价是精度。一个权重压成整数再还原回来，会有舍入误差;这个误差会顺着前向传播放大成 logit 漂移，最坏情况翻转 argmax（采样选中的那个 token 变了）。这一章要做的，就是把这笔"精度换显存"的账用真实数字算清楚:省多少、错多少、什么时候会崩。
+
+> 本章配套代码 `examples/llm-inference-from-scratch/src/stage07-quantization.ts`，`VOCAB_SIZE=256 | seed=42`，deterministic（重跑数字完全一致）。下文所有数字来自这份代码的真实运行输出。**重要 caveat 先说**:配套用的是合成的近均匀随机权重，这是量化的**最好情形**——真实 LLM 权重是 heavy-tailed（重尾，少数权重幅值远大于多数），绝对漂移会更大。可迁移的是**相对结论**,不是绝对数值。后文反复会标。
+
+## 量化到底在做什么:一个数的对称映射
+
+先把机制讲透，再讲它怎么坏。
+
+量化的核心是一个线性映射:把一段浮点区间均匀地铺到整数网格上。配套用的是 symmetric quantization(对称量化，零点固定在 0)——这是权重量化的标准做法，因为权重大致以 0 为中心,花一个 zero-point(零点偏移)去平移区间几乎不赚,还把反量化(dequant)搞复杂。
+
+对称量化只存一个元数据:scale(缩放因子)。算法三步:
+
+```
+scale = absmax / qmax        // absmax = 这组数的绝对值最大值
+q     = round(w / scale)     // 量化:浮点 -> 整数网格
+w'    = q * scale            // 反量化:整数网格 -> 近似浮点
+```
+
+`qmax` 是 b-bit 有符号整数的正向上限:int8 是 127,int4 是 7。看配套代码 `stage07-quantization.ts`:
+
+```typescript
+// qmax for a b-bit SIGNED integer. int8 -> 127, int4 -> 7. We use the symmetric
+// range [-qmax, qmax] (i.e. 255 of the 256 int8 codes, dropping -128) because a
+// symmetric range keeps round(0)=0 exact and avoids a lopsided quantization grid.
+function qmaxForBits(bits: number): number {
+  return (1 << (bits - 1)) - 1;
+}
+```
+
+这里有个容易被忽略的取舍:int8 明明有 256 个码位,我们只用 255 个(丢掉 -128)。为什么?因为对称区间 `[-127, 127]` 才能让 `round(0) = 0` 严格成立——0 是权重里最高频的值附近,让它精确映射到 0 比多榨一个码位重要。这是"对称"二字真正买到的东西。
+
+### 为什么用 absmax 而不是均值/标准差
+
+量化函数第一遍扫的是 absmax,不是 mean 或 std:
+
+```typescript
+// pass 1: absmax over the slice. absmax (not std/mean) because the grid must span
+// the most extreme value or that value clips — and a clipped weight is an
+// unbounded error, the worst kind. This is precisely why ONE outlier poisons a
+// whole per-tensor group: it stretches absmax so every normal weight gets a coarse
+// grid, while per-channel confines the damage to the outlier's own channel.
+let absmax = 0;
+for (let i = 0; i < count; i++) {
+  const v = Math.abs(src[start + i * stride]);
+  if (v > absmax) absmax = v;
+}
+const scale = Math.max(absmax / qmax, SCALE_EPS);
+```
+
+这个选择是整章的伏笔。网格必须覆盖最极端的那个值,否则它会被 clip(截断到 qmax),而 clip 是**无界误差**——最坏的一种误差。但反过来:**absmax 由最大值决定,意味着一个离群值就能把整个网格撑粗。** 这正是后面 outlier 灾难的根。
+
+注意 `Math.max(..., SCALE_EPS)` 这个地板。`SCALE_EPS = 1e-12`。这不是洁癖:
+
+```typescript
+// Invariant: scale > 0 always. An all-zero group has absmax 0, which would make
+// scale 0 and produce 0/0 = NaN on dequant. We floor scale at a tiny epsilon so a
+// dead channel dequantizes to exactly 0 instead of NaN — this is a real failure
+// mode in sparse/pruned models, not a hypothetical.
+const SCALE_EPS = 1e-12;
+```
+
+**失败模式 #0(最朴素的那个)**:一个全零的 channel(剪枝/稀疏模型里很常见)absmax = 0 → scale = 0 → 反量化时 `0/0 = NaN`,一个 NaN 顺着矩阵乘法污染整层 logit,整个 batch 的输出全废。地板把死 channel 安全地反量化成精确的 0。这种"看似冗余的防御性代码"是顺序敏感且必须的,不是可删的洁癖。
+
+## 第一笔账:省多少显存
+
+`stage07` 的 `[a]` 段直接报内存占用(精确算术,标 est. 因为是按矩阵尺寸算出来的,不是测出来的):
+
+```
+quantizable weights = 262144 params
+float64 (baseline) =   2.00 MiB (est.)  1.0x smaller
+float16            = 512.00 KiB (est.)  4.0x smaller
+int8               = 256.00 KiB (est.)  8.0x smaller
+int4               = 128.00 KiB (est.)  16.0x smaller
+```
+
+线性关系一目了然:bit 数砍一半,体积砍一半。int8 相对 float64 是 8x,int4 是 16x。这就是搬运量的减少倍数——decode 既然 memory-bound,这个倍数近似就是带宽收益的上限。
+
+但权重不是唯一的显存大户。**第 02 / 05 章我们反复算过 KV cache 的账**:它随 `seq × batch` 线性涨,长上下文下经常比权重还大。所以 KV 也要独立量化(实践中常见组合是权重走 int4、KV 走 int8):
+
+```
+KV cache @ seq=512 batch=16:
+float64 (baseline) =  16.00 MiB (est.)  1.0x smaller
+int8               =   2.00 MiB (est.)  8.0x smaller
+int4               =   1.00 MiB (est.)  16.0x smaller
+```
+
+这里有个关键判断:KV 量化和权重量化是**两条独立的主线**,因为它们卡在不同地方。
+
+- **weight-only 量化**省的是模型常驻显存 + decode 时每个 token 都要重搬的权重带宽。这条线最成熟,int4 早已是生产标配。
+- **KV cache 量化**直接砍第 02 / 05 章那本越写越厚的 KV 账,让同样的显存能塞更长的 context 或更大的 batch。这条线难一点,因为 KV 是 activation(激活值,前向算出来的中间结果)的缓存,而 activation 的离群值问题比权重严重得多——后面会讲为什么这是真正的战场。
+
+配套对哪些权重量化、哪些保留高精度,也是有讲究的:
+
+```typescript
+// Build a model whose every weight matrix is fake-quantized. RMSNorm gains are left
+// in float64 on purpose: they are O(dModel) tiny vectors (negligible memory) but
+// multiply every activation, so quantizing them buys nothing and hurts a lot — real
+// engines keep norm/scale params and often the embedding in higher precision for
+// exactly this reason. We quantize the big matmul weights, which are >99% of params.
+```
+
+RMSNorm 的 gain 是 `O(dModel)` 的小向量,占显存可忽略,但它乘到每一个 activation 上——量化它省不下什么、却毁掉一切。真实引擎也是这么干的:量化占 99%+ 参数的大矩阵,把 norm / scale / 经常还有 embedding 留在高精度。**量化不是越激进越好,是挑对地方激进。**
+
+## 第二笔账:错多少——fake-quant 与漂移度量
+
+怎么测精度损失?配套用的是 fake-quant(伪量化):量化到整数网格后,**立刻反量化回 float64**,再跑正常的浮点 kernel。
+
+```typescript
+// What we ACTUALLY do here (and what every "fake-quant" / simulated-quant path in a
+// real framework also does): quantize a weight to the integer grid, then immediately
+// DEQUANTIZE back to float64 and run the normal float kernels. The arithmetic the
+// model sees is the *rounded* weight. ... The drift we measure is exactly the drift
+// a true int8 kernel would produce, because both compute on the same rounded values.
+```
+
+为什么这样测是诚实的?因为模型看到的是**舍入后的权重**,而真正的 int8 kernel 算的也是同一批舍入后的值——两者数值上等价。fake-quant 把"量化注入的数值误差"这唯一一个我们关心的东西,从"写 int8 矩阵乘法 kernel"这件正交的工程里隔离出来。这一章只谈误差,不谈 kernel。
+
+度量用两个,缺一不可(代码 `core/metrics.ts`,在 `stage07` 里组合使用):
+
+- `maxLogitDrift` —— L∞ 范数(取最大单点偏差),抓那个把 argmax 翻掉的灾难 logit。
+- `perplexity` 漂移 —— 抓 argmax 侥幸没翻、但整个分布已经偏掉的情况。
+
+```typescript
+// maxLogitDrift is L∞ (catches the one catastrophic logit that flips an argmax);
+// perplexity drift catches a distribution skew that argmax happens to survive. We
+// need both: a scheme can ace one and fail the other.
+```
+
+跑出来的精度损失曲线(`[b]` 段,baseline `argmax=[2,46] PPL=300.37`):
+
+```
+int8 per-tensor   drift=2.60e-2  PPL=299.54 (Δ-0.83)  argmax kept
+int8 per-channel  drift=3.43e-2  PPL=300.55 (Δ+0.18)  argmax FLIPPED
+int4 per-tensor   drift=3.71e-1  PPL=294.58 (Δ-5.80)  argmax FLIPPED
+int4 per-channel  drift=4.22e-1  PPL=295.02 (Δ-5.35)  argmax kept
+```
+
+第一个硬结论:**int4 的漂移比 int8 大约 10 倍**(`3.71e-1` vs `2.60e-2`)。原因是网格密度:int8 有 255 个网格档位,int4 只有 15 个。bit 砍一半不是误差翻倍,是误差量级跳一档。这就是"精度-显存"三角里最直白的一条边:int4 省一倍显存,买单的是一个数量级的精度。
+
+第二个结论会让人意外:**在这个 no-outlier 场景里,per-channel 并没有更好,甚至略差。** per-channel 是给每个输出 channel(矩阵的每一列)单独算 scale,而 per-tensor 是整个矩阵共用一个 scale。直觉上 per-channel 更精细应该更好,但这里它的 PPL 反而略升:
+
+```
+-> per-channel here is NOT better (slightly worse): with near-uniform
+   weights and no outliers, every column's absmax ≈ the tensor absmax, so
+   per-channel's extra scales just add rounding noise. Its payoff is
+   outlier-specific.
+```
+
+道理很干净:权重近均匀、没有离群值时,每一列的 absmax 都约等于整个 tensor 的 absmax——per-channel 多算的那一堆 scale 没带来更细的网格,只多引入了一点舍入噪声。**per-channel 不是无条件更好,它的回报是 outlier-specific 的。** 这一步是下一节的反衬:你得先看到它在好情形下不赚,才理解它在坏情形下为什么是救命的。
+
+> ⚠ 别过度解读这些绝对数:`Δ-0.83` 这种 PPL 居然下降,纯属合成数据的噪声(toy 模型对舍入有偶然的正反馈),换真实重尾权重会一致变差。可迁移的是**排序**:int4 漂移 > int8;无 outlier 时 per-channel ≈ per-tensor。
+
+## ✦ 真正的战场:离群值
+
+到这里铺垫完了。现在讲这一章——也是整个 LLM 量化领域——真正的难点。
+
+**weight-only int4 早就是成熟技术。难的从来不是权重,是 activation 的离群值。** 这句话值得拆开说。Transformer 的激活值里存在所谓 emergent outlier features(涌现离群特征):模型规模过了某个阈值(经验上 ~6.7B)后,会出现少数几个维度,其幅值比其他维度大几个数量级,而且这些大值是模型正常工作所**依赖**的,不是噪声。一旦这些离群通道存在,naive 的 per-tensor int8 就崩了——因为前面讲过,scale 由 absmax 决定,一个离群值把 scale 撑粗,所有正常通道被挤进网格底部的几个档位里,整个 tensor 的有效精度被这一个值毁掉。
+
+这正是 SmoothQuant、AWQ 这一系列方法存在的全部理由:它们做的不是"更聪明地舍入",而是"想办法让那几个离群通道不要污染其他人的 scale"。
+
+配套用一个植入的离群通道把这件事复现出来(`[c]` 段):把第 0 层 `w1`(FFN 的 gate 投影矩阵,`[dModel=64, dFF=256]`)的某一列放大 50 倍,模拟真实模型里的离群特征。
+
+```typescript
+const OUTLIER_COL = 3;
+const OUTLIER_FACTOR = 50; // 50x the surrounding weights — deliberately brutal
+function withOutlier(m: Model): Model {
+  const w0 = m.layers[0].w1;
+  const data = Float64Array.from(w0.data);
+  const cols = w0.shape[1];
+  for (let r = 0; r < w0.shape[0]; r++) data[r * cols + OUTLIER_COL] *= OUTLIER_FACTOR;
+  // ...
+}
+```
+
+为什么挑 `w1` 而不是 Q 投影?代码注释说得很到位:`w1` 的输出 channel 经 SiLU → 门控 → 下投影 → 残差 → logit,一路畅通地到达输出;而 Q 投影的离群值会被注意力分数的 softmax 大量冲刷掉。**要演示灾难,得让离群值真的能传到输出。** 这是诊断思路:不是随便挑个矩阵注入,是挑那个误差能传播到可观测处的矩阵。
+
+植入后,同样是 int8,per-tensor 和 per-channel 的命运彻底分叉:
+
+```
+int8 per-tensor   drift=2.59e-1  argmax FLIPPED
+int8 per-channel  drift=3.39e-2  argmax kept
+-> per-channel confines the outlier to its own 1/256 scale and keeps argmax;
+   per-tensor smears it over all 256 channels and flips the output. ~7-8x gap.
+```
+
+对照上一节 no-outlier 时 per-channel `3.43e-2` ——它几乎没变(`3.39e-2`),因为它把那个离群值锁进了它自己那 1/256 的 scale 里,其余 255 列毫发无伤。而 per-tensor 从无 outlier 的 `2.60e-2` 暴涨到 `2.59e-1`(约 10 倍),argmax 翻了。**这就是 per-channel 的全部价值:它不让一个 channel 的灾难外溢成整个 tensor 的灾难。** 上一节它在好情形下"白交了 scale 的成本",在这里连本带利赚回来。
+
+## ✦ 失败模式:per-tensor int4 撞上离群值
+
+把上面这件事推到 int4,就是这一章最该被记住的崩溃(`[d]` 段)。int4 只有 15 个网格档位,当 per-tensor 的单一 scale 被一个 50x 离群值撑到极致,每个正常权重都塌进 0 附近的少数几档——矩阵实际上被摧毁了:
+
+```
+per-tensor  int4 drift = 1.35e+0   argmax FLIPPED (was [2,122], now [212,23])
+per-channel int4 drift = 4.65e-1   argmax FLIPPED (now [2,46])
+blow-up ratio (per-tensor / per-channel) = 2.9x worse drift
+```
+
+注意 per-tensor int4 的漂移 `1.35e+0` ——超过 1.0(logit 尺度),argmax 不是简单翻一下,而是落到了**完全无关**的 token(`[2,122]` → `[212,23]`,两个位置全错)。这不是"答案变差了",是"输出彻底乱码"。
+
+```typescript
+// int4 has only 15 grid levels, so when per-tensor's single scale is stretched to
+// cover a 50x outlier, every NORMAL weight collapses onto a handful of levels near
+// zero — the matrix is effectively destroyed. ... This is the concrete reason
+// production int4 is NEVER naive per-tensor: it is always per-channel/per-group,
+// plus dedicated outlier handling.
+```
+
+但请注意一个诚实的细节:**per-channel int4 在这里也翻了 argmax**(`now [2,46]`)。它把漂移压到了 per-tensor 的约 1/3(`blow-up ratio = 2.9x`),损害被遏制了,但 4-bit 本身就是真有损的,toy 模型又没有容错冗余,一个 token 还是翻了。代码注释把结论钉死:
+
+```
+-> a SINGLE outlier channel + naive per-tensor int4 corrupts the whole layer.
+   per-channel softens it ~3x but 4-bit still flips a token here: at int4 you
+   need per-group + outlier handling, not just per-channel.
+   This is why outliers are the #1 problem in LLM quantization.
+```
+
+这就是为什么生产级 int4 **从来不是** naive per-tensor。它的标配是:per-channel / per-group(按更细的组分别算 scale)打底,再叠专门的离群值处理——给离群通道单独留高精度(mixed-precision,混合精度),或者用旋转/平滑的技巧(SmoothQuant 把离群值从 activation"挪"一部分到权重,AWQ 按激活幅值给重要通道保护)把离群能量摊开。**展示崩溃本身就是目的:只跑 happy path 的 demo 会让你完全不理解这一整套机器为什么存在。**
+
+这也回答了为什么 KV cache 量化比 weight-only 更棘手:KV 缓存的是 activation,而离群值问题在 activation 上比在权重上严重得多。weight-only int4 早就稳了,activation / KV 的低 bit 量化才是 SmoothQuant / AWQ 这一代工作真正在啃的骨头。
+
+## ⚡ 开放问题:activation 量化与极低 bit 的前沿
+
+**2024-2025 的生产现状**已经很清楚,几条主线并行:
+
+- **FP8** 成了 H100 / B200 的原生支持格式(8-bit 浮点,有指数位,对离群值比 int8 友好得多)。DeepSeek-V3 直接用 FP8 **训练**,等于把推理量化的友好性做进了模型前端——训练时就让权重/激活适配低精度,而不是事后硬压。这是一个方向性的转变:量化不再只是推理期的后处理,开始往训练期前移。
+- **per-group int4**(GPTQ / AWQ 这一系)是 weight-only 的成熟答案,把本章的 per-channel 进一步细化到组级 + 校准数据驱动的舍入。
+- **KV cache 量化**(int8 / fp8 KV)已是长上下文服务的标配,直接兑现第 02 / 05 章的 KV 显存账。
+
+但有一块**目前没有通用解,仍在活跃研究**:**activation 离群值的低 bit 量化,以及 int4 以下(int3 / int2 / 1.58-bit)的极低 bit 量化。** 本章 `[d]` 已经演示了,即使 per-channel,int4 在有离群值时仍可能翻 token——这不是实现没做好,是 4-bit 的信息容量在离群值面前本就吃紧。SmoothQuant 用平滑、AWQ 用激活感知保护、QuaRot / SpinQuant 用旋转矩阵把离群值"转散",各有适用边界,没有一个方法对所有模型/所有层都最优;什么时候该混合精度、什么时候该旋转、离群值在不同架构(MoE、超长上下文)里怎么迁移,都还在 per-model 调。再往下到 1.58-bit(BitNet 那条线),则需要从训练阶段就改架构,不是推理期能后压出来的。**"用更低 bit 而不崩"这件事的通用配方,到 2026 年仍然没有定论。**
+
+## 把三角钉在数字上
+
+这是吞吐与显存的收尾章,回头看"精度-显存-速度"三角,现在每条边都有数字:
+
+| 维度 | int8 | int4 |
+|---|---|---|
+| 显存 / 带宽(省) | 8x | 16x |
+| logit 漂移(无 outlier) | `2.60e-2` | `3.71e-1`(~10x 于 int8) |
+| 有 outlier 时(per-tensor) | argmax FLIPPED | drift `1.35e+0`,输出乱码 |
+| 有 outlier 时(per-channel) | argmax kept | argmax 仍可能翻,但 drift ~1/3 |
+
+三角的取舍法则:**bit 越低,省得越多,但对离群值越脆;per-channel/per-group 是把离群值伤害局部化的最低成本手段,int4 还要再叠离群值处理。** 至于"省了带宽到底快了多少"——把量化接进真实推理路径、配上前几章的 KV cache 与连续批处理,在第 08 章的基准测试里用真实 tok/s 收口。
+
+> 再强调一次 caveat:本章数字来自近均匀合成权重(量化的最好情形),真实重尾权重会更差。请只迁移**相对排序与失败模式**:int4 漂移 > int8;per-channel 仅在 outlier 下胜出;per-tensor int4 + outlier 必崩。

--- a/src/content/library/llm-inference/08-全栈基准与就业冲刺.md
+++ b/src/content/library/llm-inference/08-全栈基准与就业冲刺.md
@@ -1,0 +1,195 @@
+---
+title: "全栈基准与就业冲刺：所有优化同台，把推理账算到底"
+slug: "08"
+collection: "llm-inference"
+order: 8
+summary: "收尾章。把前七章逐个验证过的 KV 缓存、连续批、PagedAttention、量化、投机解码全叠到同一个 toy 引擎、同一组混长请求上，跑一次端到端基准，建一张'优化 × 指标'矩阵——证明没有银弹。最后把 toy 里的每个概念对位 vLLM/SGLang/TensorRT-LLM/EAGLE，给一张从本书到工业代码的迁移地图。"
+topics:
+  - "LLM 推理"
+tags: []
+createdAt: "2026-06-21T08:00:00.000Z"
+updatedAt: "2026-06-21T08:00:00.000Z"
+---
+
+面试官把三条曲线推到你面前——tok/s、TTFT、显存占用——问你"下一个该上什么优化"。这是推理工程师上岗第一周最值钱的能力，也是这一章唯一要练的东西。它不考你会不会手写 attention kernel（那个能力的天花板很低，CUDA 模板满地都是），它考你能不能从这三条线反推系统现在卡在哪：是 prefill bound（首 token 慢，算力打满）、decode bound（逐 token 慢，但 GPU 闲着等显存搬运）、还是显存 bound（并发上不去，一开高并发就 OOM）。判断错了方向，你接下来两周的工作全白做——给一个 decode bound 的系统去优化 prefill kernel，曲线纹丝不动。
+
+前七章每章只证一个优化在隔离条件下成立。问题是，一个读者带着"缓存 10x、批处理 4x、量化 2x"离场，脑子里会做乘法，期待叠起来 80x。这是错的，而且这个错本身就是基准章存在的全部理由：优化共享瓶颈，所以收益不可乘；有的优化无损（缓存、分页），有的有损（量化);有的根本不在你以为的那一列贡献收益（连续批和分页在我们这个单线程 CPU 上 tok/s 一动不动)。这一章把它们全摆到同一张台子上,用同一把诚实的尺子量,逼出那张让"没有银弹"无可辩驳的矩阵。
+
+配套代码全在 `examples/llm-inference-from-scratch/src/stage08-benchmark.ts`。本章所有数字来自它的真实运行输出,绝对值偏小是因为这是 64 维 4 层的玩具模型跑在单线程 scalar JS（标量浮点循环，没有 SIMD/GPU)上——能迁移的不是绝对 tok/s,是相对形状:加速比、有损/无损的分野、随瓶颈翻转的并发曲线。
+
+## 一把诚实的尺子:基准为什么这么搭
+
+先说测量契约,因为基准章最容易在这里造假。`stage08-benchmark.ts` 顶部那段注释把规矩写死了:
+
+- 耗时全用 `performance.now()` 真测,每次测量前先 warmup(第一次调用付 JIT 编译的钱,不计入);
+- 显存全是对 config 做精确算术,打印时标 `(est.)`,**绝不**用 RSS(进程实际内存,含 runtime 噪声);
+- "没改变输出"是用 `maxLogitDrift`(最后一个 token 的 logit 向量的 L∞ 差,即逐元素最大绝对差)对拍参考路径**证明**出来的,不是嘴上说说。
+
+为什么要这么较真?因为基准造假有个经典手法:给连续批、分页这种"在 GPU 上才有意义"的优化也报一个假的 tok/s 加速。在单线程 CPU 上,连续批没有批量 matmul 可以并行,分页不改变任何算术——它们的真实收益分别在 makespan(完成全部请求的总时长)和显存里。诚实的做法是去测它们收益真正落地的那个指标,并大声说出来"它们的 tok/s 列不是它们价值所在"。报一个假的 4x 是违约;报真正的杠杆不是。
+
+工作负载是固定的:3 个请求,prompt 长度 `[3, 48, 235]`,每个 decode 12 个 token,`seed=42`。混长是故意的——短 prompt 是 decode bound,长 prompt 是 prefill bound,不同请求压不同的优化,这正是"没有银弹"变得可见的方式。同一组请求喂给每一个变体,所以矩阵每一行都是只差一个优化的受控实验。
+
+参考轨迹的建立有个**承重的坑**,值得单独点出来。`decodeRequest()` 里 prefill 阶段喂完所有 prompt token 后,**最后一个 prompt token 的 logits 已经预测了第一个生成 token**,直接拿来用:
+
+```ts
+// from src/stage08-benchmark.ts — decodeRequest()
+let lastPrefill: Float64Array = new Float64Array(0);
+const prefillMs = timeIt(() => {
+  for (const id of req) lastPrefill = step(id, cache);
+});
+let next = argmax(lastPrefill);
+```
+
+注释把后果说透了:如果你"补喂"一遍最后那个 token 来取首 token logits,会让 cache 多走一步,这条轨迹就和精确参考(REF)悄悄分叉,**腐蚀掉之后每一次 drift 比较**。缓存的贪心路径必须和 REF 逐比特一致,否则量化那行的 drift 数字就是脏的。这是第 02 章 KV 缓存那个"off-by-one 把 cache 写错位"教训的直系后代——缓存正确性的 bug 永远是静默的。
+
+## 矩阵:六行优化,八列指标
+
+把优化一行一行叠上去,跑出来的记分卡是这样(speedup 相对 baseline tok/s):
+
+| optimization | tok/s | speedup | TTFT ms | ITL p50 | ITL p99 | weights | KV | drift L∞ | lossy |
+|---|---|---|---|---|---|---|---|---|---|
+| baseline (no cache) | 25.3 | 1.00x | 96.5 | 17.999 | 101.356 | 2.00 MiB | - | 0 (exact) | exact |
+| +KV cache | 2455.1 | 97.18x | 104.4 | 0.366 | 0.534 | 2.00 MiB | 644.00 KiB | 0 (exact) | exact |
+| +continuous batch | 2455.1 | 97.18x | 104.4 | 0.366 | 0.534 | 2.00 MiB | 644.00 KiB | 0 (exact) | exact |
+| +paged KV | 2455.1 | 97.18x | 104.4 | 0.366 | 0.534 | 2.00 MiB | 672.00 KiB | 0 (exact) | exact |
+| +int8 quant | 2194.9 | 86.88x | 102.9 | 0.368 | 1.227 | 256.56 KiB | 672.00 KiB | 2.48e-2 | LOSSY |
+| +speculative(K=3) | 132.3 | 5.24x | 102.0 | 3.487 | 18.376 | 256.56 KiB | 1.31 MiB | 0 (exact) | exact |
+
+逐列读,这就是面试要的功夫。
+
+### KV 缓存:唯一一个给了真加速的
+
+25.3 → 2455.1 tok/s,**97.18x**。这是把 baseline 的每步 `O(seq²)` 重算(每生成一个 token 就把整条序列重新前向一遍)换成 `O(seq)` 增量解码的结果。看 ITL(inter-token latency,逐 token 间隔)更直观:baseline p50 是 18ms,缓存后 0.366ms;baseline p99 飙到 101ms(序列越长重算越慢,尾部延迟爆炸),缓存后 0.534ms——p50/p99 几乎贴平,因为每步工作量从此恒定。drift 是 0(exact),因为缓存路径**就是**参考路径,算术分毫不差。
+
+注意 TTFT(time to first token,首 token 延迟)反而从 96.5 微升到 104.4ms。这不是 bug:TTFT 量的是最长请求(235 token prompt)的 prefill 耗时,缓存不改 prefill 的算术,这点抖动是测量噪声。**这是第一个反直觉点**:缓存把 decode 提速 97 倍,对 TTFT 一点忙帮不上。decode bound 和 prefill bound 是两堵不同的墙。
+
+### 连续批 + 分页:tok/s 一动不动,这才是诚实
+
+接下来两行,tok/s、TTFT、ITL **完全照抄**缓存那行。这不是偷懒,是单线程 CPU 的物理事实。连续批的真实杠杆是调度:静态批处理要等一批里最慢的请求跑完才放新请求进来(head-of-line blocking,队头阻塞),连续批一有空位立刻回填。`stage08-benchmark.ts` 用 makespan(完成步数)去量这个杠杆,note 里写着 `makespan 36->32 steps (-4)`——静态批 36 步,连续批 32 步,省 4 步。代码里的 `simulateContinuousBatch()` 就是个 O(n) 扫描,每步给所有在飞请求减一,退休完成的、立刻回填等待队列:
+
+```ts
+// from src/stage08-benchmark.ts — simulateContinuousBatch()
+while (active.length > 0) {
+  step++;
+  for (let i = 0; i < active.length; i++) active[i]--;
+  for (let i = active.length - 1; i >= 0; i--) {
+    if (active[i] <= 0) {
+      active.splice(i, 1);
+      if (nextReq < remaining.length) active.push(remaining[nextReq++]); // 立刻回填 = "连续"
+    }
+  }
+}
+```
+
+**关键判断:连续批救不了单请求延迟**。它提高的是集群吞吐和 GPU 利用率,一个孤零零的请求该多慢还多慢。面试时如果有人说"我们上了连续批,单用户体验会变好"——错,他混淆了 throughput 和 latency。
+
+分页那行 KV 从 644.00 涨到 672.00 KiB,看起来还变多了?这是 toy 工作负载下的特例:我们的请求短(最长才 235+12 token),连续分配本来就没浪费多少,而分页要把每个序列向上取整到整数个 block(16 token 一块),小请求反而多占了不到一块的零头。分页的真实价值在 note 里:`reserve 1.50 MiB->672.00 KiB actual`。连续分配的引擎为了避免 decode 中途搬家,常常**按 maxSeq 预留**——给每个序列预留最大长度的空间,哪怕它只用一点点,这 1.50 MiB 就是这么来的(3 个序列 × 按 maxSeq=256 预留)。分页按需分配,实占 672 KiB。省下的那 850 KiB 不在 tok/s 里,在能塞下多少并发里,下一节就靠它。
+
+### 量化:拿 4x 权重内存换真实漂移
+
+int8 量化是这张表里**第一个有损**的优化。weights 从 2.00 MiB 砸到 256.56 KiB——8 字节 float64 概念上压到 1 字节 int8,接近 4x(没到正好 4x 是因为 embedding/norm 的计数细节)。代价写在 drift 列:`2.48e-2`,lossy 标成 LOSSY。这是真做出来的:`quantizeDequantize()` 对每个权重矩阵做对称 per-tensor 量化(scale = max|w|/127),把值 round 到 int8 网格再 dequant 回 float64,所以**唯一**的变化就是那个 round 误差,跑真前向,量真 drift。
+
+```ts
+// from src/stage08-benchmark.ts — quantizeDequantize()
+const scale = maxAbs === 0 ? 1 : maxAbs / 127;
+for (let i = 0; i < t.data.length; i++) {
+  const q = Math.max(-127, Math.min(127, Math.round(t.data[i] / scale)));
+  out[i] = q * scale; // 值是 float64,但被钉在 int8 网格上 —— 注入的就是量化误差
+}
+```
+
+两个工程细节值得记:第一,norm 参数(LayerNorm/RMSNorm 的缩放)**故意不量化**——它们很小但精度敏感,一个被量化的归一化器会扭曲下游每一个激活,真实引擎都把 norm/scale 留在高精度。量化的 4x 收益全在那几个大矩阵上,量化 norm 只增加 drift 不省内存。第二,tok/s 反而**降了**(2455→2194.9)。为什么省了内存还更慢?因为我们在 dequant 回 float64 后才算——CPU 上没有真正的 int8 matmul 指令收益,只多了 dequant 的开销。**这是 toy 的局限,必须标注**:真实 GPU 上 int8/FP8 tensor core 才是量化提速的来源,我们这里只能诚实地给出"内存省了、精度掉了、CPU 上还略慢"这个不完整但不撒谎的画面。
+
+**面试判断:量化提不了并发上限**。等等——它不是省了权重内存吗?注意省的是**权重**(模型参数,所有并发请求共享一份),不是 **KV cache**(每个请求各自一份)。并发上限由 per-request KV 决定,量化权重对它毫无帮助。要降 KV 得靠 KV 量化或 GQA,那是另一回事。
+
+### 投机解码:0 漂移,但赌的是 accept rate
+
+最后一行最微妙。speedup 只有 5.24x,ITL p50 跳到 3.487ms、p99 到 18.376ms,KV **翻倍**到 1.31 MiB,但 drift 是 **0(exact)**,lossy 标 exact。
+
+投机解码(speculative decoding)是让一个便宜的 draft 模型(我们用 int8 量化模型)一口气提议 K 个 token,target 模型(全精度)去**验证**,只保留它同意的前缀,第一个不一致处用 target 自己的 token 纠正。关键性质:**输出和 target 自己贪心解码的 token 逐个相同,无论 draft 多烂**——draft 只影响速度,永不影响结果。所以它对 fp baseline 的 drift 是 0(exact),风险全在 wall-clock 列。
+
+note 写着 `accept 100%, 2x KV; CPU verify is serial (tok/s pessimistic)`。三个信息:
+
+1. **accept 100%**:在 K=3、温和量化 draft 下,draft 提议全被接受。
+2. **2x KV**:draft 和 target 各持一份 cache,代码里 `kvBytes: peakKv * 2`——这是投机解码真实的显存代价,不是 toy 假造。
+3. **tok/s 悲观**:真实引擎在一次批量前向里验证 K 个 token,我们单线程 scalar 只能串行 loop,所以我们的 5.24x 严重低估。能迁移的信号是 **accept rate** 和 **verify 调用次数**,不是这个 tok/s。
+
+**两个独立的面试判断点**:投机解码降不了显存(它翻倍 KV),也提不了 batch 上限(同理)。它只在算力闲、显存松、draft 够准时赚。判断对一个系统该不该上它,先问"我撞的是算力墙还是显存墙"。
+
+### 为什么 speedup 列不能相乘
+
+97.18 × 86.88 × 5.24 不是总加速。这些优化共享同一个瓶颈——decode 这一步的算术工作量。缓存把它从 `O(seq²)` 降到 `O(seq)` 之后,后面的优化都在这个已经摊薄的基础上动,边际收益锐减,甚至像量化那样在 CPU 上倒贴。**这就是"没有银弹"的数值证据**:优化不是正交的乘法因子,是在抢同一堵墙前的位置。
+
+(一个诚实标注:ITL p99 列在小 N 下其实是 p95 近似。12×3=36 步的样本撑不起真正的 p99,代码里 `interTokenLatency` 暴露的就是 p95,列名标 p99 但用 p95,运行输出里也明说了。基准章连这种细节都不能糊。)
+
+## 固定显存预算下能塞几个请求:撞哪堵墙,哪个优化才有用
+
+矩阵证明了优化不可乘。第二张表证明**同一个优化在不同瓶颈下价值完全不同**。给定 4 MiB 的 KV 预算、seqLen=128,问每种存储策略能塞下几个并发序列——这正是真实引擎 admission controller(准入控制器,决定新请求能不能进)算的数:
+
+```
+budget = 4.00 MiB (est.), seqLen=128
+  contiguous reserve-to-maxSeq    512.00 KiB/seq ->    8 concurrent seqs
+  +paged KV (block=16)            256.00 KiB/seq ->   16 concurrent seqs
+  paged but MHA (no GQA)          512.00 KiB/seq ->    8 concurrent seqs
+  +speculative (2x KV)            512.00 KiB/seq ->    8 concurrent seqs
+```
+
+四行,四个判断:
+
+- **连续预留 8 个 → 分页 16 个**。同样 4 MiB,分页翻倍并发。因为连续按 maxSeq 预留,128 长的序列也占满预留;分页只占实际用的 block。这是 PagedAttention 在生产里最值钱的一刀。
+- **分页但用 MHA(关掉 GQA)又掉回 8 个**。GQA(grouped-query attention,多个 query head 共享一组 KV head)在我们的 DEFAULT_CONFIG 里是 `nKVHeads=2 < nHeads=4`,KV 直接减半。关掉它(`nKVHeads=nHeads=4`)KV 翻倍,分页省的全吐回去。**GQA 和分页是叠加的两刀**,缺一个并发就腰斩。
+- **投机解码 → 砍回 8 个**。它 2x KV,在显存受限时是**负优化**——你为了 decode 提速,反手把能服务的并发砍半。
+
+结论一句话:**优化的边际收益取决于你撞的是哪堵墙(compute vs memory)**。显存松、算力紧 → 投机解码赚。显存紧 → 投机解码是自残,该上的是分页 + GQA + KV 量化。读懂 tok/s/TTFT/显存三条曲线反推瓶颈,就是为了不在错的墙上砸资源。
+
+## 失败模式:把所有优化无脑全开,反而慢 42 倍
+
+新手最危险的信念:优化堆满,旋钮全拧到头。`stage08-benchmark.ts` 的 `[C]` 段专门造了这个翻车现场——K=8 的长投机 horizon 配一个 int4 级(`quantizeModel(model, 8)`,网格粗到离谱)的 draft:
+
+```
+plain cached decode (longest req): 7.82 ms
+all-on misconfigured spec decode : 328.07 ms  (41.94x of cached)
+draft accept rate: 68.8%  <- down from 100% at K=3
+output drift vs fp reference: 0.00e+0  <- still EXACT
+结论: SLOWER (41.94x), output still correct
+```
+
+读这个数据:accept rate 从 K=3 时的 100% 崩到 68.8%。粗糙的 int4 draft 频繁猜错,而 K=8 意味着每次猜错丢弃的 token 更多。每一轮你都付 K 个 draft 步 + 一个 verify pass,然后扔掉大半。42x 这个数还被一个细节放大了:我们每次拒绝都**重建整个 draft cache**(`resyncDraftCache()` 从头重放 prompt + 已提交 token)。代码注释把这个 trade-off 写清楚了——真实引擎保一个 rollback 指针只回退被拒的后缀,我们选了"正确性优先于指针手术",因为一个失同步的投机 draft cache 是全书最阴险的静默腐蚀 bug,宁可慢也要明显正确。
+
+最该记住的是:**输出 drift 还是 0.00e+0,完全正确**。这让失败变得隐蔽——结果对的,你只是花了 42 倍的钱买这个对的结果。投机解码只在 draft 够准(accept rate 高)时赚;草率 draft + 长 horizon + 每次拒绝重建 cache = 纯亏 compute。"全开 ≠ 最优"不是口号,是上面这个 41.94x 的收据。
+
+这也呼应第 06 章投机解码那章的核心:accept rate 是唯一重要的旋钮,K 调大只在 accept rate 撑得住时才有意义,否则放大的是浪费而非收益。
+
+## ⚡ 前沿:从 toy 引擎到 2024-2025 生产栈的迁移地图
+
+这本书的每个概念在工业代码里都有对应物。把它们对位起来,就是你从"手写过 toy"到"读得懂 vLLM 源码"的桥。但要先说清一个**目前无通用解、仍在研究**的问题:**这张矩阵里的最优组合是 workload-dependent 的,没有一个配置在所有流量形态下都最优,而在线自适应地选优化组合至今没有通用方案**。
+
+具体说:给定一个时刻的混合流量(长 prompt 短输出的 RAG 请求、短 prompt 长输出的 agent 请求、突发的高并发),最优的 batch 大小、是否开投机、投机的 K、chunked prefill 的 chunk 大小、KV 量化的位宽——这些参数的最优解随流量分布漂移。vLLM 的 chunked prefill、SGLang 的调度、TensorRT-LLM 的 in-flight batching 各有一套启发式,但都是手调阈值 + 经验规则,没有一个系统能在线根据实时 tok/s/TTFT/显存曲线自动重配优化组合。这正是本章练的"读曲线反推瓶颈"能力今天还得靠人脑的原因——把它自动化是开放问题。学术上有 SLO-aware scheduling、learned admission control 的探索,但 2025 年还没有一个能在生产里取代资深推理工程师判断的通用方案。
+
+对位表(toy 概念 → 该读的工业代码):
+
+| 本书 toy 概念 | 对应章 | 2024-2025 生产实现 | 去读什么 |
+|---|---|---|---|
+| KV cache(`forwardStep`) | 02 | 所有引擎的基础 | vLLM `Attention` backend |
+| 连续批(`simulateContinuousBatch`) | 04 | vLLM continuous batching、TensorRT-LLM in-flight batching | vLLM `Scheduler`、TRT-LLM `GptManager` |
+| 分页 KV(`pagedKvBytes`, block=16) | 05 | vLLM PagedAttention、chunked prefill | vLLM `BlockManager` + PagedAttention CUDA kernel |
+| GQA(`nKVHeads<nHeads`) | 02/05 | Llama-3/Mistral 标配,降 KV | HF `transformers` GQA 实现 |
+| int8 量化(`quantizeDequantize`) | 07 | FP8(H100 tensor core)、AWQ、GPTQ | `llm-compressor`、AWQ kernel、TRT-LLM FP8 |
+| 投机解码(`speculativeDecode`) | 06 | EAGLE/EAGLE-2、Medusa、draft-model spec | vLLM spec decode、EAGLE 官方实现 |
+| 准入控制(`maxConcurrentSeqs`) | 08 | vLLM/SGLang admission + preemption | vLLM `Scheduler` 抢占逻辑 |
+| 前缀复用(本书未做) | — | SGLang RadixAttention(共享 prompt 前缀的 KV) | SGLang `RadixCache` |
+
+迁移建议:别从读 CUDA kernel 开始,从读**调度器**开始(vLLM 的 `Scheduler`、SGLang 的调度循环)。kernel 是可替换的实现细节,调度器才是把本章这张矩阵里所有 trade-off 实际权衡落地的地方——它决定哪个请求进、批多大、显存怎么分、什么时候抢占。你在这章学的"读三条曲线反推瓶颈、判断下一个该上什么优化",在生产里就活在调度器的代码和日志里。
+
+## 推理工程师能力清单
+
+上岗你真正要会的,按价值排序:
+
+1. **读 benchmark 反推瓶颈**(本章):从 tok/s/TTFT/显存三条线判断 prefill/decode/memory bound,指出下一个该上的优化。这是第一周最值钱的,也是这章唯一练的。
+2. **算显存账**:给定模型 + 序列长 + 并发,手算 KV 占用(`estimateKVBytes` 的逻辑),知道 GQA/分页/KV 量化各省多少。OOM 是生产最常见的事故。
+3. **判断优化的适用条件**:每个优化"何时坏、代价什么",而不是"它有多快"。本章矩阵的每一行都是一条判断。
+4. **理解无损 vs 有损**:量化有损要 eval 兜底,投机/缓存/分页无损可以放心上。把"输出等价性"作为独立验收维度(就像本章的 drift 列)。
+5. **读调度器代码**:vLLM/SGLang 的调度循环,把概念映射到生产。
+6. **kernel 优化**:排最后。能写当然好,但它的天花板低、可替换、且大部分时间不是瓶颈所在。
+
+如果这一章只带走一句话:**没有银弹,优化不可乘,每个优化都在某堵墙前有用、在另一堵墙前有害,而你的工作是先读懂曲线知道自己撞的是哪堵墙**。这本书从第 01 章一个 `O(seq²)` 的朴素前向起步,到这里你手上有一个能算真实 tok/s、能对拍证明无损、能算清显存账的 toy 推理栈——它小,但每个概念都在生产栈里有名有姓的对应物。接下来该做的,是带着这张迁移地图去读 vLLM。

--- a/src/utils/library-paths.ts
+++ b/src/utils/library-paths.ts
@@ -49,6 +49,23 @@ export const LEARNING_PATHS: LearningPathMeta[] = [
     ],
   },
   {
+    id: 'llm-inference-engineer-from-scratch',
+    title: 'LLM 推理工程师 · 从零构建',
+    audience: '面向就业 · 进推理引擎 / infra 团队',
+    goal: '不用现成推理框架，亲手实现前向、KV 缓存、采样、连续批处理、PagedAttention、投机解码、量化，并用 toy 权重实测 tok/s、延迟与显存。',
+    steps: [
+      { collection: 'llm-inference', slug: '00', why: '先建地图:自回归 + prefill/decode 两阶段 + tok/s 的真相' },
+      { collection: 'llm-inference', slug: '01', why: 'tiny transformer 前向:token→logits,注意力 O(seq²) 的根' },
+      { collection: 'llm-inference', slug: '02', why: 'KV 缓存:把 decode 从 O(n²) 砍成 O(n),回报最大的一步' },
+      { collection: 'llm-inference', slug: '03', why: '采样:温度/top-k/top-p,decode 热路径上的取舍' },
+      { collection: 'llm-inference', slug: '04', why: '连续批处理:让 GPU 不空转,把吞吐榨干' },
+      { collection: 'llm-inference', slug: '05', why: 'PagedAttention:像 OS 管内存一样管 KV 缓存碎片' },
+      { collection: 'llm-inference', slug: '06', why: '投机解码:小模型抢跑、大模型一次验一串降延迟' },
+      { collection: 'llm-inference', slug: '07', why: '量化 int8/int4:用精度换显存与带宽' },
+      { collection: 'llm-inference', slug: '08', why: '全栈基准:所有优化同台,把推理账算到底 + 面试冲刺' },
+    ],
+  },
+  {
     id: 'agent-engineer-from-scratch',
     title: 'Agent 工程师 · 从零构建',
     audience: '面向就业 · 做 AI 原生应用 / Agent 平台',

--- a/src/utils/library.ts
+++ b/src/utils/library.ts
@@ -51,6 +51,11 @@ export const LIBRARY_COLLECTIONS: Record<string, LibraryCollectionMeta> = {
     description: '从零用 TypeScript 手写一个向量检索引擎——倒排/BM25、暴力 KNN、HNSW、IVF-PQ 量化、Hybrid + Rerank、分片与评测——每章用合成数据实测 recall / QPS / 内存。',
     order: 1,
   },
+  'llm-inference': {
+    title: 'LLM 推理引擎',
+    description: '从零用 TypeScript 手写一个会算真实 tok/s 的推理栈——前向、KV 缓存、采样、连续批处理、分页 KV、投机解码、量化、基准测试——每章配可跑代码与实测数字，讲透为什么/何时坏/代价。',
+    order: 2,
+  },
   // survey/课程系列，orders 10+。
   'ai-app-engineering': {
     title: 'AI 应用工程',


### PR DESCRIPTION
## Summary

「从零做透」书系第 3 本:《LLM 推理引擎》。从零用 TS 手写一个会算真实 tok/s 的推理栈,9 章 + 配套可跑代码,补推理工程师就业路径。多 agent(Workflow)产出,主流程集成验证。

### 9 章(每章绑定可跑 stage,引用其实测 tok/s/延迟/显存)
00 自回归与 prefill/decode 两阶段 · 01 tiny transformer 前向 · 02 KV 缓存 · 03 采样 · 04 连续批处理 · 05 PagedAttention · 06 投机解码 · 07 量化 int8/int4 · 08 全栈基准+面试冲刺

### 代码 examples/llm-inference-from-scratch
- 纯计算 toy 权重,**零运行时依赖**,离线 CPU 可跑。
- core: tensor/model/tokenizer/metrics（手写 matmul/softmax/rope,无 BLAS）。
- 真实数字:tok/s、prefill/decode 分离延迟、KV 显存 (est.)、各优化加速比。绝对值偏悲观(纯 JS f64)、可迁移的是相对加速比,已标注。
- 全量 tsc 干净;stage 01-05/07/08 在 180s 内跑通,stage06(投机解码,计算最重)需更长时间但能跑完(确定性,数字与章节一致)。

### 集成 & 验证
- library.ts 注册 llm-inference(order 2);新增 llm-inference-engineer-from-scratch 学习路径(9 步)。
- build 346 页(zod 过=学习路径全解析)+ lint 干净 + 无 github 占位 + playwright 04 章 820px 零溢出 6/6 TOC。